### PR TITLE
Improve error logging format for duplicate category creation

### DIFF
--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -62,7 +62,7 @@ class DatabaseService {
           insert.run(category, isDefault)
         } catch (error) {
           // Category might already exist
-          console.log(`Category ${category} already exists:`, error)
+          console.log('Category already exists:', { category, error })
         }
       })
       console.log('Default categories creation completed')

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -58,8 +58,9 @@ class DatabaseService {
         try {
           // Set Development (first category) as default - use 1/0 for SQLite boolean
           const isDefault = index === 0 ? 1 : 0
-          console.log('Creating category:', { category, is_default: isDefault })
+          console.log('Attempting to create category:', { category, is_default: Boolean(isDefault) })
           insert.run(category, isDefault)
+          console.log('Created category:', { category, is_default: Boolean(isDefault) })
         } catch (error) {
           // Check if this is a unique constraint violation (category already exists)
           const isUniqueConstraint = error && typeof error === 'object' && 

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -53,27 +53,23 @@ class DatabaseService {
     
     if (existingCount.count === 0) {
       console.log('No categories found, creating default categories...')
-      const insert = this.db.prepare('INSERT INTO categories (name, is_default) VALUES (?, ?)')
+      const insert = this.db.prepare('INSERT OR IGNORE INTO categories (name, is_default) VALUES (?, ?)')
       defaultCategories.forEach((category, index) => {
         try {
           // Set Development (first category) as default - use 1/0 for SQLite boolean
           const isDefault = index === 0 ? 1 : 0
           console.log('Attempting to create category:', { category, is_default: Boolean(isDefault) })
-          insert.run(category, isDefault)
-          console.log('Created category:', { category, is_default: Boolean(isDefault) })
-        } catch (error) {
-          // Check if this is a unique constraint violation (category already exists)
-          const isUniqueConstraint = error && typeof error === 'object' && 
-            ((error as any).code === 'SQLITE_CONSTRAINT' || (error as any).code === 'SQLITE_CONSTRAINT_UNIQUE' ||
-             (error as any).message?.includes('UNIQUE') || (error as any).message?.includes('CONSTRAINT'))
+          const result = insert.run(category, isDefault)
           
-          if (isUniqueConstraint) {
-            console.warn('Category already exists during initialization:', { category, error })
-          } else {
-            // Re-throw unexpected database errors (IO, schema, etc.)
-            console.error('Unexpected error creating default category:', { category, error })
-            throw error
+          if (result.changes === 0) {
+            console.warn('Category already exists during initialization:', { category, is_default: Boolean(isDefault) })
+          } else if (result.changes > 0) {
+            console.log('Created category:', { category, is_default: Boolean(isDefault) })
           }
+        } catch (error) {
+          // Re-throw unexpected database errors (IO, schema, etc.)
+          console.error('Unexpected error creating default category:', { category, error })
+          throw error
         }
       })
       console.log('Default categories creation completed')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Initialization now tolerates duplicate default categories and no longer fails on duplicates, improving startup reliability.
  * Logging around default-category setup has been enhanced for clearer diagnostics.
  * Other database errors still halt initialization to preserve data integrity.
  * No changes to public APIs or end-user features; behavior otherwise unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->