### PR TITLE
Add auto-refresh functionality for today's tasks and improve duration…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,6 +368,7 @@ When working with report calculations:
   - **Future days**: Returns start time (creating zero duration)
   - **DRY principle**: This helper is used by all three duration functions to prevent logic duplication
   - **Testing**: Manual test available in `test-helper.js` covering past/today/future edge cases
+  - **Time zone note**: Returns end times in minutes based on local calendar day; date-only strings must be persisted/compared in local time (e.g., "YYYY-MM-DD derived from local getters") to avoid UTC off-by-one-day errors
 
 When adding new settings:
 


### PR DESCRIPTION
… calculation logic

- Introduce auto-refresh for task durations, refreshing every 15 seconds when viewing today's tasks.
- Add `startAutoRefresh` and `stopAutoRefresh` functions with proper lifecycle management.
- Refactor duration calculation to handle last task scenarios, considering past, present, and future dates.
- Ensure consistency between task list durations and daily report totals.
- Update `CLAUDE.md` with details on auto-refresh and updated duration logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Auto-refresh for today’s view: task list and daily report update every 15 seconds while viewing today; starts/stops on date change and unmount.
  - Pre-sorted task view for consistent ordering and rendering.

- Improvements
  - Date-local handling for all date inputs and API calls to avoid UTC day mismatches.
  - Date-aware last-task boundaries: past → midnight, today → now (or 0 if start is future), future → 0.
  - Per-task duration rounding: floor minutes per task before aggregation; totals and category breakdowns updated.
  - Midnight rollover guard to prevent incorrect updates.

- Documentation
  - Expanded guidance on auto-refresh, rollover behavior, settings workflow, and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->