### PR TITLE
Add semi-automatic semantic versioning system and support scripts

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -68,17 +68,21 @@ jobs:
           shopt -u nocasematch
 
       - name: Bump version
+        env:
+          BUMP_TYPE: ${{ steps.bump-type.outputs.bump_type }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ steps.bump-type.outputs.pr_title }}
         run: |
-          echo "📈 Bumping ${{ steps.bump-type.outputs.bump_type }} version..."
+          echo "📈 Bumping ${BUMP_TYPE} version..."
 
           # Create temporary commit message file to avoid shell injection
           COMMIT_FILE=$(mktemp)
           
           # Write commit message to file with proper escaping
-          cat > "$COMMIT_FILE" << 'EOF'
-          chore: bump ${{ steps.bump-type.outputs.bump_type }} version
+          cat > "$COMMIT_FILE" << EOF
+          chore: bump ${BUMP_TYPE} version
 
-          Merged PR #${{ github.event.pull_request.number }}: ${{ steps.bump-type.outputs.pr_title }}
+          Merged PR #${PR_NUMBER}: ${PR_TITLE}
 
           🤖 Generated with [Claude Code](https://claude.ai/code)
 
@@ -87,7 +91,7 @@ jobs:
 
           # Read commit message from file safely and pass to script
           COMMIT_MSG=$(cat "$COMMIT_FILE")
-          node scripts/bump-version.js ${{ steps.bump-type.outputs.bump_type }} "$COMMIT_MSG"
+          node scripts/bump-version.js "${BUMP_TYPE}" "$COMMIT_MSG"
           
           # Clean up temporary file
           rm -f "$COMMIT_FILE"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,6 +15,11 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    
+    # Prevent concurrent version bumps to avoid conflicts
+    concurrency:
+      group: version-bump-main
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code
@@ -22,6 +27,8 @@ jobs:
         with:
           # Fetch full history for proper git operations
           fetch-depth: 0
+          # Use the base branch
+          ref: main
           # Use GitHub token with write permissions
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -42,11 +49,14 @@ jobs:
           PR_TITLE="${{ github.event.pull_request.title }}"
           echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
 
+          # Enable case-insensitive pattern matching
+          shopt -s nocasematch
+
           # Determine bump type from PR title
-          if [[ "$PR_TITLE" =~ \[MAJOR\]|\[major\]|major: ]]; then
+          if [[ "$PR_TITLE" =~ \[(major)\]|major: ]]; then
             echo "bump_type=major" >> $GITHUB_OUTPUT
             echo "🚀 Detected MAJOR version bump from PR title"
-          elif [[ "$PR_TITLE" =~ \[MINOR\]|\[minor\]|minor: ]]; then
+          elif [[ "$PR_TITLE" =~ \[(minor)\]|minor: ]]; then
             echo "bump_type=minor" >> $GITHUB_OUTPUT
             echo "📈 Detected MINOR version bump from PR title"
           else
@@ -54,21 +64,33 @@ jobs:
             echo "🔧 Default PATCH version bump"
           fi
 
+          # Disable case-insensitive matching to avoid side effects
+          shopt -u nocasematch
+
       - name: Bump version
         run: |
           echo "📈 Bumping ${{ steps.bump-type.outputs.bump_type }} version..."
 
-          # Create commit message that includes PR info
-          COMMIT_MSG="chore: bump ${{ steps.bump-type.outputs.bump_type }} version
+          # Create temporary commit message file to avoid shell injection
+          COMMIT_FILE=$(mktemp)
+          
+          # Write commit message to file with proper escaping
+          cat > "$COMMIT_FILE" << 'EOF'
+          chore: bump ${{ steps.bump-type.outputs.bump_type }} version
 
           Merged PR #${{ github.event.pull_request.number }}: ${{ steps.bump-type.outputs.pr_title }}
 
           🤖 Generated with [Claude Code](https://claude.ai/code)
 
-          Co-Authored-By: Claude <noreply@anthropic.com>"
+          Co-Authored-By: Claude <noreply@anthropic.com>
+          EOF
 
-          # Run version bump script
+          # Read commit message from file safely and pass to script
+          COMMIT_MSG=$(cat "$COMMIT_FILE")
           node scripts/bump-version.js ${{ steps.bump-type.outputs.bump_type }} "$COMMIT_MSG"
+          
+          # Clean up temporary file
+          rm -f "$COMMIT_FILE"
 
       - name: Get new version info
         id: version-info
@@ -81,8 +103,13 @@ jobs:
         run: |
           echo "📤 Pushing version bump commit..."
 
-          # Push the commit
-          git push origin main
+          # Pull latest changes from origin main with fast-forward-only to ensure we're up-to-date
+          echo "🔄 Pulling latest changes from origin/main (fast-forward-only)..."
+          git pull --ff-only origin main
+
+          # Push the current HEAD to main explicitly
+          echo "⬆️ Pushing current HEAD to main..."
+          git push origin HEAD:main
 
           echo "✅ Successfully pushed version ${{ steps.version-info.outputs.new_version }}"
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    
+
     # Prevent concurrent version bumps to avoid conflicts
     concurrency:
       group: version-bump-main
@@ -45,15 +45,18 @@ jobs:
 
       - name: Determine version bump type
         id: bump-type
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
           echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
 
           # Enable case-insensitive pattern matching
           shopt -s nocasematch
 
           # Determine bump type from PR title
-          if [[ "$PR_TITLE" =~ \[(major)\]|major: ]]; then
+          # MAJOR: Explicit tags, breaking change indicators, or conventional commit breaking patterns
+          if [[ "$PR_TITLE" =~ \[(major)\]|major:|breaking\ change|!:|\w+!: ]]; then
             echo "bump_type=major" >> $GITHUB_OUTPUT
             echo "🚀 Detected MAJOR version bump from PR title"
           elif [[ "$PR_TITLE" =~ \[(minor)\]|minor: ]]; then
@@ -64,7 +67,7 @@ jobs:
             echo "🔧 Default PATCH version bump"
           fi
 
-          # Disable case-insensitive matching to avoid side effects
+          # Restore shopt state
           shopt -u nocasematch
 
       - name: Bump version
@@ -77,7 +80,7 @@ jobs:
 
           # Create temporary commit message file to avoid shell injection
           COMMIT_FILE=$(mktemp)
-          
+
           # Write commit message to file with proper escaping
           cat > "$COMMIT_FILE" << EOF
           chore: bump ${BUMP_TYPE} version
@@ -92,7 +95,7 @@ jobs:
           # Read commit message from file safely and pass to script
           COMMIT_MSG=$(cat "$COMMIT_FILE")
           node scripts/bump-version.js "${BUMP_TYPE}" "$COMMIT_MSG"
-          
+
           # Clean up temporary file
           rm -f "$COMMIT_FILE"
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,96 @@
+name: Version Bump
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  version-bump:
+    # Only run when PR is merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history for proper git operations
+          fetch-depth: 0
+          # Use GitHub token with write permissions
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      - name: Determine version bump type
+        id: bump-type
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
+
+          # Determine bump type from PR title
+          if [[ "$PR_TITLE" =~ \[MAJOR\]|\[major\]|major: ]]; then
+            echo "bump_type=major" >> $GITHUB_OUTPUT
+            echo "🚀 Detected MAJOR version bump from PR title"
+          elif [[ "$PR_TITLE" =~ \[MINOR\]|\[minor\]|minor: ]]; then
+            echo "bump_type=minor" >> $GITHUB_OUTPUT
+            echo "📈 Detected MINOR version bump from PR title"
+          else
+            echo "bump_type=patch" >> $GITHUB_OUTPUT
+            echo "🔧 Default PATCH version bump"
+          fi
+
+      - name: Bump version
+        run: |
+          echo "📈 Bumping ${{ steps.bump-type.outputs.bump_type }} version..."
+
+          # Create commit message that includes PR info
+          COMMIT_MSG="chore: bump ${{ steps.bump-type.outputs.bump_type }} version
+
+          Merged PR #${{ github.event.pull_request.number }}: ${{ steps.bump-type.outputs.pr_title }}
+
+          🤖 Generated with [Claude Code](https://claude.ai/code)
+
+          Co-Authored-By: Claude <noreply@anthropic.com>"
+
+          # Run version bump script
+          node scripts/bump-version.js ${{ steps.bump-type.outputs.bump_type }} "$COMMIT_MSG"
+
+      - name: Get new version info
+        id: version-info
+        run: |
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "📊 New version: $NEW_VERSION"
+
+      - name: Push changes
+        run: |
+          echo "📤 Pushing version bump commit..."
+
+          # Push the commit
+          git push origin main
+
+          echo "✅ Successfully pushed version ${{ steps.version-info.outputs.new_version }}"
+
+      - name: Summary
+        run: |
+          echo "🎉 Version bump completed!"
+          echo "   • PR: #${{ github.event.pull_request.number }}"
+          echo "   • Bump type: ${{ steps.bump-type.outputs.bump_type }}"
+          echo "   • New version: ${{ steps.version-info.outputs.new_version }}"
+          echo ""
+          echo "📝 Git tags will be created manually during release process."

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
   actions: read
 
 jobs:
@@ -36,7 +37,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
 
       - name: Configure Git
         run: |
@@ -49,26 +49,36 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          # Enable strict shell error handling
+          set -euo pipefail
+          IFS=$'\n\t'
+          
+          # Set up cleanup trap to restore shell state
+          cleanup() {
+            shopt -u nocasematch 2>/dev/null || true
+          }
+          trap cleanup EXIT
+          
           echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
 
           # Enable case-insensitive pattern matching
           shopt -s nocasematch
 
-          # Determine bump type from PR title
+          # Determine bump type from PR title with anchored, grouped patterns
           # MAJOR: Explicit tags, breaking change indicators, or conventional commit breaking patterns
-          if [[ "$PR_TITLE" =~ \[(major)\]|major:|breaking\ change|!:|\w+!: ]]; then
-            echo "bump_type=major" >> $GITHUB_OUTPUT
+          if [[ "$PR_TITLE" =~ (\[major\]|^major:|^.*!:.*|breaking[[:space:]]change) ]]; then
+            BUMP_TYPE="major"
             echo "🚀 Detected MAJOR version bump from PR title"
-          elif [[ "$PR_TITLE" =~ \[(minor)\]|minor: ]]; then
-            echo "bump_type=minor" >> $GITHUB_OUTPUT
+          elif [[ "$PR_TITLE" =~ (\[minor\]|^minor:) ]]; then
+            BUMP_TYPE="minor"
             echo "📈 Detected MINOR version bump from PR title"
           else
-            echo "bump_type=patch" >> $GITHUB_OUTPUT
+            BUMP_TYPE="patch"
             echo "🔧 Default PATCH version bump"
           fi
 
-          # Restore shopt state
-          shopt -u nocasematch
+          # Export bump type to GitHub output
+          echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
 
       - name: Bump version
         env:
@@ -110,13 +120,23 @@ jobs:
         run: |
           echo "📤 Pushing version bump commit..."
 
-          # Pull latest changes from origin main with fast-forward-only to ensure we're up-to-date
-          echo "🔄 Pulling latest changes from origin/main (fast-forward-only)..."
-          git pull --ff-only origin main
+          # Fetch latest changes from origin to get current state
+          echo "🔄 Fetching latest changes from origin..."
+          git fetch origin
 
-          # Push the current HEAD to main explicitly
-          echo "⬆️ Pushing current HEAD to main..."
-          git push origin HEAD:main
+          # Rebase our bump commit onto the latest origin/main
+          echo "🔀 Rebasing bump commit onto latest origin/main..."
+          if ! git rebase origin/main; then
+            echo "❌ Rebase failed - likely due to conflicts"
+            echo "This suggests origin/main has conflicting changes since PR merge"
+            git rebase --abort
+            echo "Manual intervention may be required"
+            exit 1
+          fi
+
+          # Push using force-with-lease for safety (only if remote hasn't changed since fetch)
+          echo "⬆️ Pushing rebased commit with force-with-lease..."
+          git push origin HEAD:main --force-with-lease
 
           echo "✅ Successfully pushed version ${{ steps.version-info.outputs.new_version }}"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,15 +15,25 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run format` - Format all source code files with Prettier
 - `npm run format:check` - Check if code formatting is consistent with Prettier
 - `npm run install-hooks` - Install git hooks for automatic markdown and code formatting
+- `npm run version:major` - Manually bump major version
+- `npm run version:minor` - Manually bump minor version
+- `npm run version:patch` - Manually bump patch version
 
 ### CI/CD Pipeline
 
-__GitHub Actions Workflow__ (`.github/workflows/ci.yml`):
+__GitHub Actions Workflows__:
 
+**CI Pipeline** (`.github/workflows/ci.yml`):
 - Runs on pull requests and pushes to main branch
 - Tests on Node.js 20 (Maintenance) and 22 (Active LTS)
 - Executes `npm run test:coverage` and `npm run build`
 - Uploads coverage reports to Codecov from the Node.js 22 job
+
+**Version Bump** (`.github/workflows/version-bump.yml`):
+- Runs automatically when PRs are merged to main
+- Analyzes PR title to determine version bump type ([MAJOR], [MINOR], or patch)
+- Updates package.json with new semantic version
+- Git tags will be created separately during manual release process
 
 __Coverage Requirements for PRs__:
 
@@ -227,3 +237,13 @@ Always consider use of sequential thinking and memory-timecatcher MCPs, especial
 Use other MCPs if this can be useful for a specific task or step.
 
 Keep the CLAUDE.md context file up-to-date with the latest changes and as compact as possible.
+
+## Versioning System
+
+TimeCatcher uses semi-automatic semantic versioning:
+
+- **Package.json**: Full semantic versions (0.20.0, 0.20.1, 0.20.2)
+- **Automatic**: PR merge triggers version bump based on title ([MAJOR], [MINOR], or patch)
+- **Manual**: Use `npm run version:major|minor|patch` for local version management
+- **Git Tags**: Created separately during manual release process
+- **Documentation**: See `docs/VERSIONING.md` for complete workflow details

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run format` - Format all source code files with Prettier
 - `npm run format:check` - Check if code formatting is consistent with Prettier
 - `npm run install-hooks` - Install git hooks for automatic markdown and code formatting
-- `npm run version:major` - Manually bump major version
-- `npm run version:minor` - Manually bump minor version
-- `npm run version:patch` - Manually bump patch version
+
+See docs/VERSIONING.md for the full versioning workflow and npm commands.
 
 ### CI/CD Pipeline
 
@@ -240,10 +239,4 @@ Keep the CLAUDE.md context file up-to-date with the latest changes and as compac
 
 ## Versioning System
 
-TimeCatcher uses semi-automatic semantic versioning:
-
-- **Package.json**: Full semantic versions (0.20.0, 0.20.1, 0.20.2)
-- **Automatic**: PR merge triggers version bump based on title ([MAJOR], [MINOR], or patch)
-- **Manual**: Use `npm run version:major|minor|patch` for local version management
-- **Git Tags**: Created separately during manual release process
-- **Documentation**: See `docs/VERSIONING.md` for complete workflow details
+TimeCatcher uses semi-automatic semantic versioning with PR-based automatic bumps. See docs/VERSIONING.md for complete workflow details, npm commands, and release processes.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,164 @@
+# Semantic Versioning System
+
+TimeCatcher uses a semi-automatic semantic versioning system that automatically bumps version numbers on PR merges.
+
+## Overview
+
+- **Package.json**: Contains full semantic versions (e.g., `0.20.0`, `0.20.1`, `0.20.2`)
+- **Automatic Bumping**: Version incremented on every PR merge based on title
+- **Git Tags**: Created manually during release process (planned for future implementation)
+
+## Automatic Version Bumping
+
+### On PR Merge
+
+When a pull request is merged to the `main` branch, the version is automatically bumped based on the PR title:
+
+- **Default**: Patch version bump (e.g., `0.20.0` → `0.20.1`)
+- **`[MINOR]` or `minor:`**: Minor version bump (e.g., `0.20.0` → `0.21.0`)
+- **`[MAJOR]` or `major:`**: Major version bump (e.g., `0.20.0` → `1.0.0`)
+
+### Examples
+
+```
+feat: add new feature                    → 0.20.0 → 0.20.1 (patch)
+feat: [MINOR] add user authentication    → 0.20.0 → 0.21.0 (minor)
+feat: [MAJOR] breaking API changes      → 0.20.0 → 1.0.0 (major)
+fix: resolve login bug                   → 0.20.0 → 0.20.1 (patch)
+```
+
+## Manual Version Bumping
+
+For local development and testing, you can manually bump versions using npm scripts:
+
+```bash
+# Bump patch version (0.20.0 → 0.20.1)
+npm run version:patch
+
+# Bump minor version (0.20.0 → 0.21.0)  
+npm run version:minor
+
+# Bump major version (0.20.0 → 1.0.0)
+npm run version:major
+```
+
+Each command will:
+1. Update `package.json` with the new version
+2. Create a commit with the version change
+3. **Note**: Git tags will be created separately during release process
+
+## Version Workflow Details
+
+### GitHub Action Workflow
+
+The `.github/workflows/version-bump.yml` workflow:
+
+1. **Triggers**: On PR merge to `main` branch
+2. **Analyzes**: PR title to determine bump type
+3. **Updates**: `package.json` with new version
+4. **Commits**: Version change with automated message
+5. **Pushes**: Changes back to repository
+
+### Version Bump Script
+
+The `scripts/bump-version.js` script handles:
+
+- **Version parsing** and validation
+- **Package.json updates** with new versions
+- **Commit creation** with consistent messaging
+- **PR title analysis** for automatic bump type detection
+
+## Best Practices
+
+### PR Titles
+
+Use clear, descriptive PR titles with version indicators when needed:
+
+```bash
+# Patch (default) - no special indicator needed
+fix: resolve task deletion bug
+feat: improve UI responsiveness
+
+# Minor - add [MINOR] tag for new features
+feat: [MINOR] add data export functionality
+feat: [MINOR] implement dark mode
+
+# Major - add [MAJOR] tag for breaking changes  
+feat: [MAJOR] redesign database schema
+feat: [MAJOR] migrate to Vue 4
+```
+
+### Version History
+
+All version changes are tracked in Git commits with the pattern:
+```
+chore: bump [type] version
+
+Merged PR #123: [PR title]
+```
+
+## Integration with Build Process
+
+The version from `package.json` is automatically used by:
+- **Electron Builder**: App version metadata
+- **Build artifacts**: Version included in built applications
+- **About dialogs**: Can display current version to users
+
+## Checking Version Information
+
+```bash
+# Current version in package.json
+npm version
+
+# View version history
+git log --oneline --grep="chore: bump.*version"
+
+# Check specific version commit
+git show --name-only <commit-hash>
+```
+
+## Future Enhancements
+
+### Planned Release Process
+
+Git tagging will be implemented as part of a separate manual release process that will:
+- Create release tags pointing to specific versions
+- Generate release notes from commit history
+- Build and publish release artifacts
+- Create GitHub releases with proper documentation
+
+## Troubleshooting
+
+### Version Rollback
+
+To rollback a version bump:
+
+```bash
+# Revert the version commit
+git revert HEAD
+
+# Push the revert
+git push origin main
+```
+
+### Manual Version Fix
+
+If you need to manually fix a version:
+
+```bash
+# Edit package.json manually
+# Commit the change
+git add package.json
+git commit -m "fix: correct version number"
+git push origin main
+```
+
+### CI/CD Integration
+
+The version bump happens after CI passes, ensuring only validated code gets versioned. The workflow:
+
+1. PR created → CI runs tests
+2. PR approved and merged → Version bump workflow runs
+3. New version committed automatically
+
+This ensures every version number represents code that has passed all tests and quality checks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timecatcher",
-  "version": "1.0.0",
+  "version": "0.20.0",
   "description": "Task &amp; time tracking desktop app",
   "main": "dist/main/main.js",
   "scripts": {
@@ -20,7 +20,10 @@
     "format:md": "markdownlint-cli2 --fix",
     "format": "prettier --write \"{src,scripts,.github}/**/*.{ts,js,vue,json,html,css,scss,yaml,yml}\"",
     "format:check": "prettier --check \"{src,scripts,.github}/**/*.{ts,js,vue,json,html,css,scss,yaml,yml}\"",
-    "install-hooks": "cp scripts/git-hooks/* .git/hooks/ && chmod +x .git/hooks/*"
+    "install-hooks": "cp scripts/git-hooks/* .git/hooks/ && chmod +x .git/hooks/*",
+    "version:major": "node scripts/bump-version.js major",
+    "version:minor": "node scripts/bump-version.js minor",
+    "version:patch": "node scripts/bump-version.js patch"
   },
   "repository": {
     "type": "git",

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Configuration
+const PACKAGE_JSON_PATH = path.join(__dirname, '../package.json');
+
+/**
+ * Executes a git command and returns the output
+ * @param {string} command - Git command to execute
+ * @returns {string} Command output
+ */
+function execGit(command) {
+  try {
+    return execSync(`git ${command}`, { encoding: 'utf-8', stdio: 'pipe' }).trim();
+  } catch (error) {
+    throw new Error(`Git command failed: ${command}\n${error.message}`);
+  }
+}
+
+/**
+ * Reads and parses package.json
+ * @returns {object} Parsed package.json content
+ */
+function readPackageJson() {
+  try {
+    const content = fs.readFileSync(PACKAGE_JSON_PATH, 'utf-8');
+    return JSON.parse(content);
+  } catch (error) {
+    throw new Error(`Failed to read package.json: ${error.message}`);
+  }
+}
+
+/**
+ * Writes updated package.json
+ * @param {object} packageData - Updated package.json content
+ */
+function writePackageJson(packageData) {
+  try {
+    const content = JSON.stringify(packageData, null, 2) + '\n';
+    fs.writeFileSync(PACKAGE_JSON_PATH, content);
+  } catch (error) {
+    throw new Error(`Failed to write package.json: ${error.message}`);
+  }
+}
+
+/**
+ * Parses semantic version string
+ * @param {string} version - Version string (e.g., "1.2.3")
+ * @returns {object} Version components {major, minor, patch}
+ */
+function parseVersion(version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`Invalid version format: ${version}`);
+  }
+  return {
+    major: parseInt(match[1]),
+    minor: parseInt(match[2]),
+    patch: parseInt(match[3])
+  };
+}
+
+/**
+ * Formats version components into string
+ * @param {object} version - Version components {major, minor, patch}
+ * @returns {string} Formatted version string
+ */
+function formatVersion(version) {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+/**
+ * Gets the major.minor tag name from version
+ * @param {object} version - Version components {major, minor, patch}
+ * @returns {string} Tag name (e.g., "0.20")
+ */
+function getMajorMinorTag(version) {
+  return `${version.major}.${version.minor}`;
+}
+
+
+/**
+ * Bumps version in package.json and creates commit
+ * @param {string} bumpType - 'major', 'minor', or 'patch'
+ * @param {string} [commitMessage] - Optional commit message
+ */
+function bumpVersion(bumpType, commitMessage) {
+  console.log(`🚀 Bumping ${bumpType} version...`);
+
+  // Read current version
+  const packageData = readPackageJson();
+  const currentVersion = parseVersion(packageData.version);
+
+  console.log(`📋 Current version: ${formatVersion(currentVersion)}`);
+
+  // Calculate new version
+  let newVersion;
+  switch (bumpType) {
+    case 'major':
+      newVersion = { major: currentVersion.major + 1, minor: 0, patch: 0 };
+      break;
+    case 'minor':
+      newVersion = { major: currentVersion.major, minor: currentVersion.minor + 1, patch: 0 };
+      break;
+    case 'patch':
+      newVersion = { major: currentVersion.major, minor: currentVersion.minor, patch: currentVersion.patch + 1 };
+      break;
+    default:
+      throw new Error(`Invalid bump type: ${bumpType}. Use 'major', 'minor', or 'patch'.`);
+  }
+
+  const newVersionString = formatVersion(newVersion);
+
+  console.log(`📈 New version: ${newVersionString}`);
+
+  // Update package.json
+  packageData.version = newVersionString;
+  writePackageJson(packageData);
+  console.log(`✅ Updated package.json to ${newVersionString}`);
+
+  // Stage package.json for commit
+  execGit('add package.json');
+
+  // Create commit
+  const defaultMessage = `chore: bump version to ${newVersionString}
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>`;
+
+  const finalMessage = commitMessage || defaultMessage;
+  execGit(`commit -m "${finalMessage}"`);
+  console.log(`✅ Created commit with version bump`);
+
+  console.log(`🎉 Version bump complete: ${currentVersion.major}.${currentVersion.minor}.${currentVersion.patch} → ${newVersionString}`);
+  console.log(`📝 Note: Git tags will be created manually during release process`);
+}
+
+/**
+ * Determines version bump type from PR title
+ * @param {string} prTitle - Pull request title
+ * @returns {string} Bump type: 'major', 'minor', or 'patch'
+ */
+function getBumpTypeFromPRTitle(prTitle) {
+  if (!prTitle) return 'patch';
+
+  const title = prTitle.toLowerCase();
+
+  if (title.includes('[major]') || title.includes('major:')) {
+    return 'major';
+  }
+
+  if (title.includes('[minor]') || title.includes('minor:')) {
+    return 'minor';
+  }
+
+  return 'patch';
+}
+
+/**
+ * Main function - handles command line arguments
+ */
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0) {
+    console.log(`
+Usage: node bump-version.js <bump-type> [commit-message]
+       node bump-version.js --pr-title "<title>"
+
+Bump types:
+  major  - Increment major version (1.0.0 → 2.0.0), creates new major.minor tag
+  minor  - Increment minor version (1.2.0 → 1.3.0), creates new major.minor tag
+  patch  - Increment patch version (1.2.3 → 1.2.4), moves existing major.minor tag
+
+PR title mode:
+  --pr-title - Determines bump type from PR title ([MAJOR], [MINOR], or default patch)
+
+Examples:
+  node bump-version.js patch
+  node bump-version.js minor "feat: add new feature"
+  node bump-version.js --pr-title "feat: [MINOR] add user authentication"
+`);
+    process.exit(1);
+  }
+
+  try {
+    if (args[0] === '--pr-title') {
+      if (args.length < 2) {
+        throw new Error('PR title is required when using --pr-title flag');
+      }
+      const prTitle = args[1];
+      const bumpType = getBumpTypeFromPRTitle(prTitle);
+      console.log(`📝 PR Title: "${prTitle}"`);
+      console.log(`🎯 Detected bump type: ${bumpType}`);
+      bumpVersion(bumpType, args[2]);
+    } else {
+      const bumpType = args[0];
+      const commitMessage = args[1];
+      bumpVersion(bumpType, commitMessage);
+    }
+  } catch (error) {
+    console.error(`❌ Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+// Export functions for testing
+module.exports = {
+  parseVersion,
+  formatVersion,
+  getMajorMinorTag,
+  getBumpTypeFromPRTitle,
+  bumpVersion
+};
+
+// Run if called directly
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
- Introduce `docs/VERSIONING.md` to document versioning workflow and best practices.
- Add `version:major`, `version:minor`, and `version:patch` scripts to `package.json`.
- Implement `scripts/bump-version.js` for automatic version bumping based on PR titles.
- Add `.github/workflows/version-bump.yml` to automate version increments on PR merges.
- Update `CLAUDE.md` with details of the versioning system and workflow integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic semantic version bumps on merged PRs to main, detecting major/minor/patch from PR titles and exposing bump/new version outputs.
  * New CLI/npm commands for manual version bumps (major/minor/patch).

* **Documentation**
  * Added a comprehensive versioning guide with PR-title conventions, manual bump instructions, and CI/versioning workflow details.
  * CI docs updated with pipelines, Node targets, coverage thresholds, and Codecov notes.

* **Chores**
  * Project version updated to 0.20.0; CI configured to create and push version bump commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->