### PR TITLE
Update version bump workflow to use `GH_PAT` instead of `GITHUB_TOKEN…

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,7 +1,7 @@
 name: Version Bump
 
 'on':
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
 


### PR DESCRIPTION
…` for authentication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated version-bump workflow trigger to use pull_request_target.
  * Switched authentication secrets from the default token to a personal access token for checkout and PR creation.
  * No changes to application features, UI, or performance.
  * End users and daily usage are unaffected; release process behavior for contributors updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->