### PR TITLE
chore: update CI workflow to skip coverage steps for version bump bra…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,23 +43,24 @@ jobs:
         run: npm ci
 
       - name: Run tests with coverage
+        if: ${{ !startsWith(github.head_ref, 'version-bump-') }}
         run: mkdir -p test-results && npm run test:coverage
 
       - name: Publish test results
-        if: ${{ always() && !cancelled() && matrix.node-version == 22 && hashFiles('test-results/junit.xml') != '' }}
+        if: ${{ always() && !cancelled() && matrix.node-version == 22 && hashFiles('test-results/junit.xml') != '' && !startsWith(github.head_ref, 'version-bump-') }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Enforce coverage thresholds
-        if: ${{ matrix.node-version == 22 }}
+        if: ${{ matrix.node-version == 22 && !startsWith(github.head_ref, 'version-bump-') }}
         run: node scripts/check-coverage.js
 
       - name: Run build
         run: npm run build
 
       - name: Upload coverage to Codecov (Node.js 22 only)
-        if: ${{ always() && matrix.node-version == 22 && !cancelled() && hashFiles('coverage/lcov.info') != '' }}
+        if: ${{ always() && matrix.node-version == 22 && !cancelled() && hashFiles('coverage/lcov.info') != '' && !startsWith(github.head_ref, 'version-bump-') }}
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info


### PR DESCRIPTION
…nches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Optimized CI to skip tests, coverage, and reporting steps on version-bump branches, speeding up routine maintenance checks without affecting release quality.
- Tests
  - Test execution, coverage enforcement, and result publishing now run only on non–version-bump branches, reducing noise in automated reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->