### PR TITLE
fix: optimize CI workflow to skip version bump PRs and commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ concurrency:
 
 jobs:
   test:
+    # Skip CI entirely for version bump PRs and commits
+    if: |
+      !startsWith(github.head_ref, 'version-bump-') &&
+      !startsWith(github.event.pull_request.title, 'chore: bump ') &&
+      !startsWith(github.event.head_commit.message, 'chore: bump ')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -43,24 +48,23 @@ jobs:
         run: npm ci
 
       - name: Run tests with coverage
-        if: ${{ !startsWith(github.head_ref, 'version-bump-') }}
         run: mkdir -p test-results && npm run test:coverage
 
       - name: Publish test results
-        if: ${{ always() && !cancelled() && matrix.node-version == 22 && hashFiles('test-results/junit.xml') != '' && !startsWith(github.head_ref, 'version-bump-') }}
+        if: ${{ always() && !cancelled() && matrix.node-version == 22 && hashFiles('test-results/junit.xml') != '' }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Enforce coverage thresholds
-        if: ${{ matrix.node-version == 22 && !startsWith(github.head_ref, 'version-bump-') }}
+        if: ${{ matrix.node-version == 22 }}
         run: node scripts/check-coverage.js
 
       - name: Run build
         run: npm run build
 
       - name: Upload coverage to Codecov (Node.js 22 only)
-        if: ${{ always() && matrix.node-version == 22 && !cancelled() && hashFiles('coverage/lcov.info') != '' && !startsWith(github.head_ref, 'version-bump-') }}
+        if: ${{ always() && matrix.node-version == 22 && !cancelled() && hashFiles('coverage/lcov.info') != '' }}
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,13 @@ concurrency:
 
 jobs:
   test:
-    # Skip CI entirely for version bump PRs and commits
+    # Skip CI entirely for version bump PRs and commits (event-aware)
     if: |
-      !startsWith(github.head_ref, 'version-bump-') &&
-      !startsWith(github.event.pull_request.title, 'chore: bump ') &&
-      !startsWith(github.event.head_commit.message, 'chore: bump ')
+      (github.event_name == 'pull_request' && 
+       !startsWith(github.head_ref, 'version-bump-') &&
+       !startsWith(github.event.pull_request.title, 'chore: bump ')) ||
+      (github.event_name == 'push' && 
+       !startsWith(github.event.head_commit.message, 'chore: bump '))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -13,12 +13,11 @@ permissions:
 
 jobs:
   version-bump:
-    # Only run when CI workflow succeeded and it's not a version bump commit
+    # Only run when CI workflow succeeded and it's not a version bump branch
     if: |
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
-      !startsWith(github.event.workflow_run.head_branch, 'version-bump-') &&
-      !startsWith(github.event.workflow_run.head_commit.message, 'chore: bump ')
+      !startsWith(github.event.workflow_run.head_branch, 'version-bump-')
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -48,7 +47,29 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
+      - name: Check if commit is a version bump
+        id: commit-guard
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
+          echo "Checking commit message for: $COMMIT_SHA"
+
+          # Get commit message using GitHub API
+          COMMIT_MESSAGE=$(gh api repos/${{ github.repository }}/commits/$COMMIT_SHA --jq '.commit.message')
+          echo "Commit message: $COMMIT_MESSAGE"
+
+          # Check if this is a version bump commit
+          if [[ "$COMMIT_MESSAGE" =~ ^"chore: bump " ]]; then
+            echo "This is a version bump commit, skipping workflow"
+            echo "should_skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "This is not a version bump commit, proceeding"
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Find original PR for bump type detection
+        if: steps.commit-guard.outputs.should_skip != 'true'
         id: find-pr
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
@@ -90,6 +111,7 @@ jobs:
           fi
 
       - name: Determine version bump type
+        if: steps.commit-guard.outputs.should_skip != 'true'
         id: bump-type
         env:
           PR_FOUND: ${{ steps.find-pr.outputs.pr_found }}
@@ -132,6 +154,7 @@ jobs:
           echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
 
       - name: Bump version
+        if: steps.commit-guard.outputs.should_skip != 'true'
         env:
           BUMP_TYPE: ${{ steps.bump-type.outputs.bump_type }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -167,6 +190,7 @@ jobs:
           rm -f "$COMMIT_FILE"
 
       - name: Get new version info
+        if: steps.commit-guard.outputs.should_skip != 'true'
         id: version-info
         run: |
           NEW_VERSION=$(node -p "require('./package.json').version")
@@ -174,6 +198,7 @@ jobs:
           echo "📊 New version: $NEW_VERSION"
 
       - name: Create version bump branch and PR
+        if: steps.commit-guard.outputs.should_skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           NEW_VERSION: ${{ steps.version-info.outputs.new_version }}
@@ -209,6 +234,7 @@ jobs:
           echo "✅ Created PR for version $NEW_VERSION"
 
       - name: Summary
+        if: steps.commit-guard.outputs.should_skip != 'true'
         run: |
           echo "🎉 Version bump completed!"
           if [ "${{ steps.find-pr.outputs.pr_found }}" = "true" ]; then

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -27,26 +27,6 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          # Fetch full history for proper git operations
-          fetch-depth: 0
-          # Use the base branch
-          ref: main
-          # Use GitHub token with write permissions
-          token: ${{ secrets.GH_PAT }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Configure Git
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-
       - name: Check if commit is a version bump
         id: commit-guard
         env:
@@ -67,6 +47,29 @@ jobs:
             echo "This is not a version bump commit, proceeding"
             echo "should_skip=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Checkout code
+        if: steps.commit-guard.outputs.should_skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history for proper git operations
+          fetch-depth: 0
+          # Use the base branch
+          ref: main
+          # Use GitHub token with write permissions
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Setup Node.js
+        if: steps.commit-guard.outputs.should_skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Configure Git
+        if: steps.commit-guard.outputs.should_skip != 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
 
       - name: Find original PR for bump type detection
         if: steps.commit-guard.outputs.should_skip != 'true'

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -60,7 +60,7 @@ jobs:
           echo "Commit message: $COMMIT_MESSAGE"
 
           # Check if this is a version bump commit
-          if [[ "$COMMIT_MESSAGE" =~ ^"chore: bump " ]]; then
+          if [[ "$COMMIT_MESSAGE" == "chore: bump "* ]]; then
             echo "This is a version bump commit, skipping workflow"
             echo "should_skip=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -13,10 +13,12 @@ permissions:
 
 jobs:
   version-bump:
-    # Only run when CI workflow succeeded and it's not a version bump PR
-    if: github.event.workflow_run.conclusion == 'success' &&
+    # Only run when CI workflow succeeded and it's not a version bump commit
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
-      !startsWith(github.event.workflow_run.head_branch, 'version-bump-')
+      !startsWith(github.event.workflow_run.head_branch, 'version-bump-') &&
+      !startsWith(github.event.workflow_run.head_commit.message, 'chore: bump ')
     runs-on: ubuntu-latest
     timeout-minutes: 5
 


### PR DESCRIPTION
- Add job-level condition to completely skip CI for version bump operations
- Fix YAML syntax error in version-bump workflow multiline if condition
- Remove redundant step-level version-bump exclusions from CI workflow
- Prevent unnecessary CI runs and resource waste for automated version bumps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized CI skip for automated version-bump commits/branches via a commit-message guard; per-step bump guards removed for clarity.
  * Version-bump workflow now pre-checks commits and skips all bump steps when appropriate to avoid redundant runs.

* **Tests**
  * Test, coverage reporting, and enforcement run consistently where applicable.
  * Codecov upload configured explicitly (named jobs, flags, verbose, non-failing behavior, token usage) for clearer and more reliable reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->