### PR TITLE
feat(report): implement dual time display and tooltips in daily report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ API methods: getCategories, addCategory, deleteCategory, updateCategory, getDefa
 - Category breakdown with progress bars
 - Status indicators: ⚠️ (missing end task), 😊 (target reached)
 - Configurable target work hours (default: 8)
-- __Dual time display__: Shows both actual time and rounded time (5-minute increments) in format: `ActualTime (RoundedTime)`
+- __Dual time display__: Shows both actual time and rounded time in format: `ActualTime (RoundedTime)`. Rounding policy: each task's duration is first floored to the nearest whole minute, then the floored duration is rounded to the nearest 5-minute increment (e.g., 2m floored → 2m → 0m rounded; 7m floored → 7m → 5m rounded). Per-task floors occur before 5-minute rounding for the rounded totals.
 - __Two-line header layout__: Title and status icons on first line, combined time totals on second line
 - __Interactive hover tooltips__: Hover over any task entry to see individual appearances with start/end times and durations
 
@@ -179,7 +179,7 @@ API methods: getCategories, addCategory, deleteCategory, updateCategory, getDefa
 - Last task duration based on date context (past: until midnight, today: until current time, future: zero)
 - Consistent rounding: `Math.floor()` per-task before aggregation
 - Auto-refresh for real-time updates when viewing today
-- __Dual totaling__: Calculates both plain sum (actual minutes) and rounded sum (each task rounded to nearest 5 minutes)
+- __Dual totaling__: Calculates both plain sum (actual minutes) and rounded sum (sum of per-task rounded durations). The rounded total is computed by rounding each individual task duration to the nearest 5 minutes, then summing those rounded values—this differs from taking the full-precision total and rounding it once.
 
 ### Report Display Structure
 
@@ -222,6 +222,18 @@ __Test Patterns__:
 - Vitest fake timers for date/time testing and avoiding real delays (`vi.useFakeTimers()`, `vi.advanceTimersByTimeAsync()`)
 - Mock complex dependencies for focused testing
 - `createElectronAPIMock()` factory function for consistent electronAPI mocking with overrides
+
+__Test Coverage Best Practices__:
+
+- Always aim for high test coverage on new features and changed code
+- Test edge cases and boundary conditions (e.g., screen edge positioning for tooltips)
+- Cover error paths and fallback scenarios (e.g., clipboard API failures with document.execCommand fallback)
+- Test component lifecycle methods and cleanup (e.g., onUnmounted callbacks)
+- Verify both success and failure states for async operations
+- Use specific assertions rather than broad existence checks (e.g., test exact CSS class presence, specific function calls)
+- Test user interactions and their visual feedback (e.g., click handlers, hover states, keyboard events)
+- Mock external dependencies appropriately while testing real logic paths
+- Test computed properties with various input scenarios to ensure reactive updates work correctly
 
 ## Common Development Tasks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,9 +169,9 @@ API methods: getCategories, addCategory, deleteCategory, updateCategory, getDefa
 - Category breakdown with progress bars
 - Status indicators: ⚠️ (missing end task), 😊 (target reached)
 - Configurable target work hours (default: 8)
-- **Dual time display**: Shows both actual time and rounded time (5-minute increments) in format: `ActualTime (RoundedTime)`
-- **Two-line header layout**: Title and status icons on first line, combined time totals on second line
-- **Interactive hover tooltips**: Hover over any task entry to see individual appearances with start/end times and durations
+- __Dual time display__: Shows both actual time and rounded time (5-minute increments) in format: `ActualTime (RoundedTime)`
+- __Two-line header layout__: Title and status icons on first line, combined time totals on second line
+- __Interactive hover tooltips__: Hover over any task entry to see individual appearances with start/end times and durations
 
 ### Duration Calculation Logic
 
@@ -179,14 +179,14 @@ API methods: getCategories, addCategory, deleteCategory, updateCategory, getDefa
 - Last task duration based on date context (past: until midnight, today: until current time, future: zero)
 - Consistent rounding: `Math.floor()` per-task before aggregation
 - Auto-refresh for real-time updates when viewing today
-- **Dual totaling**: Calculates both plain sum (actual minutes) and rounded sum (each task rounded to nearest 5 minutes)
+- __Dual totaling__: Calculates both plain sum (actual minutes) and rounded sum (each task rounded to nearest 5 minutes)
 
 ### Report Display Structure
 
-- **Day Summary**: Two-line layout with "Daily Report" title + icons, then combined time display showing `ActualTotal (RoundedTotal)`
-- **Category Summary**: Each category shows dual time format with actual and rounded totals in brackets
-- **Task Entries**: Individual tasks display combined format with actual time and rounded time in parentheses
-- **Hover Tooltips**: Show detailed breakdown of each task appearance including start time, end time, and individual duration
+- __Day Summary__: Two-line layout with "Daily Report" title + icons, then combined time display showing `ActualTotal (RoundedTotal)`
+- __Category Summary__: Each category shows dual time format with actual and rounded totals in brackets
+- __Task Entries__: Individual tasks display combined format with actual time and rounded time in parentheses
+- __Hover Tooltips__: Show detailed breakdown of each task appearance including start time, end time, and individual duration
 
 ## Design System
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,9 @@ API methods: getCategories, addCategory, deleteCategory, updateCategory, getDefa
 - Category breakdown with progress bars
 - Status indicators: ⚠️ (missing end task), 😊 (target reached)
 - Configurable target work hours (default: 8)
+- **Dual time display**: Shows both actual time and rounded time (5-minute increments) in format: `ActualTime (RoundedTime)`
+- **Two-line header layout**: Title and status icons on first line, combined time totals on second line
+- **Interactive hover tooltips**: Hover over any task entry to see individual appearances with start/end times and durations
 
 ### Duration Calculation Logic
 
@@ -176,6 +179,14 @@ API methods: getCategories, addCategory, deleteCategory, updateCategory, getDefa
 - Last task duration based on date context (past: until midnight, today: until current time, future: zero)
 - Consistent rounding: `Math.floor()` per-task before aggregation
 - Auto-refresh for real-time updates when viewing today
+- **Dual totaling**: Calculates both plain sum (actual minutes) and rounded sum (each task rounded to nearest 5 minutes)
+
+### Report Display Structure
+
+- **Day Summary**: Two-line layout with "Daily Report" title + icons, then combined time display showing `ActualTotal (RoundedTotal)`
+- **Category Summary**: Each category shows dual time format with actual and rounded totals in brackets
+- **Task Entries**: Individual tasks display combined format with actual time and rounded time in parentheses
+- **Hover Tooltips**: Show detailed breakdown of each task appearance including start time, end time, and individual duration
 
 ## Design System
 

--- a/src/components/DailyReport.test.ts
+++ b/src/components/DailyReport.test.ts
@@ -281,9 +281,8 @@ describe('DailyReport Component', () => {
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Development')
 
-      // Check that copy confirmation is shown
-      expect(wrapper.find('.copy-confirmation').exists()).toBe(true)
-      expect(wrapper.find('.copy-text').text()).toContain('Copied "Development"')
+      // Check that task is highlighted as copied
+      expect(firstTask.classes()).toContain('task-summary-copied')
     })
 
     it('should handle clipboard copy errors gracefully', async () => {
@@ -305,9 +304,24 @@ describe('DailyReport Component', () => {
       // Should fallback to document.execCommand
       expect(document.execCommand).toHaveBeenCalledWith('copy')
 
-      // Check that copy confirmation is still shown even with fallback
-      expect(wrapper.find('.copy-confirmation').exists()).toBe(true)
-      expect(wrapper.find('.copy-text').text()).toContain('Copied "Development"')
+      // Check that task is highlighted as copied even with fallback
+      expect(firstTask.classes()).toContain('task-summary-copied')
+    })
+
+    it('should only highlight one task at a time', async () => {
+      const workCategory = wrapper.findAll('.category-section')[0]
+      const firstTask = workCategory.findAll('.task-summary')[0]
+      const secondTask = workCategory.findAll('.task-summary')[1]
+
+      // Click first task
+      await firstTask.trigger('click')
+      expect(firstTask.classes()).toContain('task-summary-copied')
+      expect(secondTask.classes()).not.toContain('task-summary-copied')
+
+      // Click second task
+      await secondTask.trigger('click')
+      expect(firstTask.classes()).not.toContain('task-summary-copied')
+      expect(secondTask.classes()).toContain('task-summary-copied')
     })
   })
 

--- a/src/components/DailyReport.test.ts
+++ b/src/components/DailyReport.test.ts
@@ -43,18 +43,69 @@ describe('DailyReport Component', () => {
       name: 'Work',
       taskCount: 2,
       totalTime: '3h 30m',
+      totalTimeRounded: '3h 30m',
+      totalTimeCombined: '3h 30m (3h 30m)',
       percentage: 70,
       taskSummaries: [
-        { name: 'Development', count: 1, totalTime: '2h 15m' },
-        { name: 'Meeting', count: 1, totalTime: '1h 15m' }
+        {
+          name: 'Development',
+          count: 1,
+          totalTime: '2h 15m',
+          totalTimeRounded: '2h 15m',
+          totalTimeCombined: '2h 15m (2h 15m)',
+          appearances: [
+            {
+              startTime: '09:00',
+              endTime: '11:15',
+              duration: 135,
+              durationFormatted: '2h 15m',
+              date: '2024-01-15'
+            }
+          ]
+        },
+        {
+          name: 'Meeting',
+          count: 1,
+          totalTime: '1h 15m',
+          totalTimeRounded: '1h 15m',
+          totalTimeCombined: '1h 15m (1h 15m)',
+          appearances: [
+            {
+              startTime: '14:00',
+              endTime: '15:15',
+              duration: 75,
+              durationFormatted: '1h 15m',
+              date: '2024-01-15'
+            }
+          ]
+        }
       ]
     },
     {
       name: 'Personal',
       taskCount: 1,
       totalTime: '1h 30m',
+      totalTimeRounded: '1h 30m',
+      totalTimeCombined: '1h 30m (1h 30m)',
       percentage: 30,
-      taskSummaries: [{ name: 'Exercise', count: 1, totalTime: '1h 30m' }]
+      taskSummaries: [
+        {
+          name: 'Exercise',
+          count: 1,
+          totalTime: '1h 30m',
+          totalTimeRounded: '1h 30m',
+          totalTimeCombined: '1h 30m (1h 30m)',
+          appearances: [
+            {
+              startTime: '18:00',
+              endTime: '19:30',
+              duration: 90,
+              durationFormatted: '1h 30m',
+              date: '2024-01-15'
+            }
+          ]
+        }
+      ]
     }
   ]
 
@@ -66,6 +117,8 @@ describe('DailyReport Component', () => {
         hasEndTaskForSelectedDate: true,
         targetWorkHours: 8,
         totalTimeTracked: '5h 0m',
+        totalTimeTrackedRounded: '5h 0m',
+        totalTimeTrackedCombined: '5h 0m (5h 0m)',
         totalMinutesTracked: 300,
         categoryBreakdown: mockCategoryBreakdown
       }
@@ -75,7 +128,10 @@ describe('DailyReport Component', () => {
   describe('Component Rendering', () => {
     it('should render the report header with total time', () => {
       const header = wrapper.find('[data-testid="report-header-title"]')
-      expect(header.text()).toContain('Daily Report: 5h 0m')
+      expect(header.text()).toContain('Daily Report')
+
+      const totalTime = wrapper.find('[data-testid="total-time-display"]')
+      expect(totalTime.text()).toContain('5h 0m (5h 0m)')
     })
 
     it('should display the date title', () => {
@@ -146,7 +202,7 @@ describe('DailyReport Component', () => {
       expect(categoryTasks.text()).toBe('2 tasks')
 
       const categoryTime = workCategory.find('.category-time')
-      expect(categoryTime.text()).toBe('3h 30m')
+      expect(categoryTime.text()).toBe('3h 30m (3h 30m)')
     })
 
     it('should display singular "task" for single task count', () => {
@@ -179,16 +235,14 @@ describe('DailyReport Component', () => {
       expect(firstTask.find('.task-count').text()).toBe('1x')
     })
 
-    it('should display rounded time and actual time for each task', () => {
+    it('should display combined time for each task', () => {
       const workCategory = wrapper.findAll('.category-section')[0]
       const firstTask = workCategory.findAll('.task-summary')[0]
 
-      const roundedTime = firstTask.find('.task-time-rounded')
-      const actualTime = firstTask.find('.task-time-actual')
+      const combinedTime = firstTask.find('.task-time-combined')
 
-      expect(roundedTime.exists()).toBe(true)
-      expect(actualTime.exists()).toBe(true)
-      expect(actualTime.text()).toBe('2h 15m') // Actual time from props
+      expect(combinedTime.exists()).toBe(true)
+      expect(combinedTime.text()).toBe('2h 15m (2h 15m)') // Combined time from props
     })
   })
 

--- a/src/components/DailyReport.vue
+++ b/src/components/DailyReport.vue
@@ -116,7 +116,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, onUnmounted } from 'vue'
 import type { TaskRecord } from '@/shared/types'
 import { TASK_TYPE_NORMAL } from '@/shared/types'
 
@@ -164,6 +164,17 @@ const tooltipPosition = ref({ x: 0, y: 0 })
 
 // Copy state - track which task was last copied
 const copiedTaskName = ref('')
+
+// Timer cleanup
+let activeTimer: number | null = null
+
+// Component cleanup
+onUnmounted(() => {
+  if (activeTimer) {
+    clearTimeout(activeTimer)
+    activeTimer = null
+  }
+})
 
 // Helper function
 const clampPercent = (p: number): number => {

--- a/src/components/DailyReport.vue
+++ b/src/components/DailyReport.vue
@@ -79,6 +79,7 @@
               role="button"
               :aria-label="`Copy task name: ${task.name}`"
               :aria-describedby="getTooltipId(task.name, categoryData.name, index)"
+              aria-keyshortcuts="Enter Space"
               @mouseenter="showTooltip(task, $event, categoryData.name, index)"
               @mouseleave="hideTooltip"
               @click="copyTaskNameToClipboard(task.name)"
@@ -308,8 +309,37 @@ const handleTaskKeydown = (event: KeyboardEvent, taskName: string) => {
 
 // Generate stable tooltip ID for each task
 const getTooltipId = (taskName: string, categoryName: string, index: number) => {
+  // Sanitize input string to create valid HTML ID
+  const sanitizeForId = (input: string): string => {
+    if (!input || typeof input !== 'string') {
+      return 'unknown'
+    }
+
+    // Normalize Unicode (NFKD - Normalization Form Canonical Decomposition)
+    // Remove diacritics and convert to lowercase
+    const normalized = input
+      .normalize('NFKD')
+      .replace(/[\u0300-\u036f]/g, '') // Remove combining diacritical marks
+      .toLowerCase()
+
+    // Keep only alphanumeric characters, dashes, and underscores
+    // Replace everything else with dashes
+    const alphanumeric = normalized.replace(/[^a-z0-9_-]/g, '-')
+
+    // Collapse multiple consecutive dashes into single dash
+    const collapsed = alphanumeric.replace(/-+/g, '-')
+
+    // Remove leading/trailing dashes
+    const trimmed = collapsed.replace(/^-+|-+$/g, '')
+
+    // Return sanitized string or fallback if empty
+    return trimmed || 'unknown'
+  }
+
   // Create a stable ID that's unique per task
-  return `tooltip-${categoryName.replace(/\s+/g, '-')}-${taskName.replace(/\s+/g, '-')}-${index}`
+  const sanitizedTaskName = sanitizeForId(taskName)
+  const sanitizedCategoryName = sanitizeForId(categoryName)
+  return `tooltip-${sanitizedCategoryName}-${sanitizedTaskName}-${index}`
 }
 
 // Computed properties

--- a/src/components/DailyReport.vue
+++ b/src/components/DailyReport.vue
@@ -74,6 +74,7 @@
               v-for="(task, index) in categoryData.taskSummaries"
               :key="task.name ? `${task.name}-${index}` : index"
               class="task-summary"
+              :class="{ 'task-summary-copied': copiedTaskName === task.name }"
               @mouseenter="showTooltip(task, $event)"
               @mouseleave="hideTooltip"
               @click="copyTaskNameToClipboard(task.name)"
@@ -109,14 +110,6 @@
           <div class="appearance-time">{{ appearance.startTime }} - {{ appearance.endTime }}</div>
           <div class="appearance-duration">{{ appearance.durationFormatted }}</div>
         </div>
-      </div>
-    </div>
-
-    <!-- Copy confirmation notification -->
-    <div v-if="copyConfirmationVisible" class="copy-confirmation">
-      <div class="copy-confirmation-content">
-        <span class="copy-icon">📋</span>
-        <span class="copy-text">Copied "{{ copiedTaskName }}"</span>
       </div>
     </div>
   </div>
@@ -169,9 +162,8 @@ const tooltipContent = ref<any>(null)
 const tooltipTaskName = ref('')
 const tooltipPosition = ref({ x: 0, y: 0 })
 
-// Copy confirmation state
+// Copy state - track which task was last copied
 const copiedTaskName = ref('')
-const copyConfirmationVisible = ref(false)
 
 // Helper function
 const clampPercent = (p: number): number => {
@@ -231,7 +223,7 @@ const hideTooltip = () => {
 const copyTaskNameToClipboard = async (taskName: string) => {
   try {
     await navigator.clipboard.writeText(taskName)
-    showCopyConfirmation(taskName)
+    copiedTaskName.value = taskName
   } catch (error) {
     console.error('Failed to copy task name to clipboard:', error)
     // Fallback for older browsers or when clipboard API is not available
@@ -246,22 +238,11 @@ const copyTaskNameToClipboard = async (taskName: string) => {
       textArea.select()
       document.execCommand('copy')
       textArea.remove()
-      showCopyConfirmation(taskName)
+      copiedTaskName.value = taskName
     } catch (fallbackError) {
       console.error('Clipboard fallback also failed:', fallbackError)
     }
   }
-}
-
-// Show copy confirmation with brief animation
-const showCopyConfirmation = (taskName: string) => {
-  copiedTaskName.value = taskName
-  copyConfirmationVisible.value = true
-
-  // Hide confirmation after 1.5 seconds
-  setTimeout(() => {
-    copyConfirmationVisible.value = false
-  }, 1500)
 }
 
 // Computed properties
@@ -545,62 +526,10 @@ const getStatusText = () => {
   background: var(--bg-secondary);
 }
 
-/* Copy confirmation notification */
-.copy-confirmation {
-  position: fixed;
-  top: 20px;
-  right: 20px;
-  z-index: 1100;
-  pointer-events: none;
-  animation:
-    copySlideIn 0.3s ease-out,
-    copyFadeOut 0.3s ease-in 1.2s forwards;
-}
-
-.copy-confirmation-content {
-  background: linear-gradient(135deg, var(--verdigris), var(--emerald));
-  color: white;
-  padding: 12px 16px;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  font-weight: 500;
-}
-
-.copy-icon {
-  font-size: 16px;
-  filter: grayscale(1) brightness(2);
-}
-
-.copy-text {
-  white-space: nowrap;
-  max-width: 200px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-@keyframes copySlideIn {
-  from {
-    transform: translateX(100%);
-    opacity: 0;
-  }
-  to {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-@keyframes copyFadeOut {
-  from {
-    opacity: 1;
-    transform: translateX(0);
-  }
-  to {
-    opacity: 0;
-    transform: translateX(20px);
-  }
+/* Copied task highlighting */
+.task-summary-copied {
+  background: linear-gradient(90deg, rgba(87, 189, 175, 0.15), rgba(86, 179, 114, 0.15)) !important;
+  border-color: var(--verdigris) !important;
+  box-shadow: 0 0 0 1px rgba(87, 189, 175, 0.3);
 }
 </style>

--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -911,6 +911,7 @@ describe('App Component', () => {
       expect(typeof totalTime.combined).toBe('string')
       expect(totalTime.plain).toMatch(/^\d+h \d+m$|^\d+m$|^0m$/) // Should match time format
       expect(totalTime.rounded).toMatch(/^\d+h \d+m$|^\d+m$|^0m$/) // Should match time format
+      expect(totalTime.combined).toMatch(/^(\d+h \d+m|\d+m|0m) \((\d+h \d+m|\d+m|0m)\)$/) // Should match "primaryTime (secondaryTime)" format
     })
 
     it('should get unique categories count', () => {

--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -902,8 +902,15 @@ describe('App Component', () => {
       const vm = wrapper.vm as any
       const totalTime = vm.getTotalTimeTracked()
 
-      expect(typeof totalTime).toBe('string')
-      expect(totalTime).toMatch(/^\d+h \d+m$|^\d+m$|^0m$/) // Should match time format
+      expect(typeof totalTime).toBe('object')
+      expect(totalTime).toHaveProperty('plain')
+      expect(totalTime).toHaveProperty('rounded')
+      expect(totalTime).toHaveProperty('combined')
+      expect(typeof totalTime.plain).toBe('string')
+      expect(typeof totalTime.rounded).toBe('string')
+      expect(typeof totalTime.combined).toBe('string')
+      expect(totalTime.plain).toMatch(/^\d+h \d+m$|^\d+m$|^0m$/) // Should match time format
+      expect(totalTime.rounded).toMatch(/^\d+h \d+m$|^\d+m$|^0m$/) // Should match time format
     })
 
     it('should get unique categories count', () => {

--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -912,6 +912,7 @@ describe('App Component', () => {
       expect(totalTime.plain).toMatch(/^\d+h \d+m$|^\d+m$|^0m$/) // Should match time format
       expect(totalTime.rounded).toMatch(/^\d+h \d+m$|^\d+m$|^0m$/) // Should match time format
       expect(totalTime.combined).toMatch(/^(\d+h \d+m|\d+m|0m) \((\d+h \d+m|\d+m|0m)\)$/) // Should match "primaryTime (secondaryTime)" format
+      expect(totalTime.combined).toBe(`${totalTime.plain} (${totalTime.rounded})`) // Should be exact composition of plain and rounded
     })
 
     it('should get unique categories count', () => {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1180,7 +1180,14 @@ const getEnhancedCategoryBreakdown = computed(() => {
   return baseCategoryBreakdown.map(category => {
     const categoryData = categoryMap.get(category.categoryName)
     const plainMinutes = category.minutes
-    const roundedMinutes = roundToFiveMinutes(plainMinutes)
+
+    // Calculate rounded minutes as sum of per-task rounded values
+    const roundedMinutes = categoryData
+      ? Array.from(categoryData.tasks.values()).reduce(
+          (sum: number, task: TaskSummary) => sum + roundToFiveMinutes(task.totalMinutes),
+          0
+        )
+      : roundToFiveMinutes(plainMinutes)
 
     return {
       ...category,

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -48,9 +48,9 @@
           :date-title="dateTitle"
           :has-end-task-for-selected-date="hasEndTaskForSelectedDate"
           :target-work-hours="targetWorkHours"
-          :total-time-tracked="getTotalTimeTracked().plain"
-          :total-time-tracked-rounded="getTotalTimeTracked().rounded"
-          :total-time-tracked-combined="getTotalTimeTracked().combined"
+          :total-time-tracked="totalTimeTracked.plain"
+          :total-time-tracked-rounded="totalTimeTracked.rounded"
+          :total-time-tracked-combined="totalTimeTracked.combined"
           :total-minutes-tracked="getTotalMinutesTracked()"
           :category-breakdown="getEnhancedCategoryBreakdown"
         />
@@ -302,6 +302,10 @@ const dateInputValue = computed({
 
 const isToday = computed(() => {
   return toYMDLocalUtil(selectedDate.value) === toYMDLocalUtil(new Date())
+})
+
+const totalTimeTracked = computed(() => {
+  return getTotalTimeTracked()
 })
 
 const goToPreviousDay = () => {
@@ -1041,8 +1045,9 @@ const formatDualTime = (plainMinutes: number, roundedMinutes: number): string =>
 
 // Helper function to format minutes back to time string
 const formatTimeFromMinutes = (totalMinutes: number): string => {
-  const hours = Math.floor(totalMinutes / 60)
-  const minutes = Math.round(totalMinutes % 60)
+  const totalMinutesInt = Math.floor(totalMinutes)
+  const hours = Math.floor(totalMinutesInt / 60)
+  const minutes = totalMinutesInt % 60
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dual time display everywhere: Actual (Rounded) with per-task 5‑minute rounding and combined totals.
  - Two-line header separating title and combined totals.
  - Hover tooltips on tasks showing per-appearance start/end times and durations with edge-aware positioning.
  - Click-to-copy task names (keyboard-accessible) with visual highlight, fallback copy flow, and copy-confirmation toast.

- Documentation
  - Updated Daily Report docs covering dual totals, rounding policy, display structure, tooltips, and testing guidance.

- Tests
  - Expanded coverage for copy/keyboard accessibility, tooltips, and timing/cleanup behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->