### PR TITLE
feat(backup-&-restore): add backup and restore functionality in app s…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,7 @@ Keep the CLAUDE.md context file up-to-date with the latest changes and as compac
 
 ## Agent Coding Checklist
 
+- Always add a11y labels.
 - Tests: Always import `afterEach`, unmount and null wrappers to avoid DOM leakage. Use `vi.useFakeTimers()` + `vi.setSystemTime()` for time logic. Keep sorting tests under `describe('sortedTaskRecords')`. Assert current regex and `maxlength` omission. Run `npm run test:coverage:check` on Node 20/22.
 - IPC/runtime guards: Check `window.electronAPI` and method presence; show user-friendly errors if missing.
 - DOM timing: After opening dropdowns/toggles, `await nextTick()` before focusing/positioning.

--- a/config/coverage-excludes.json
+++ b/config/coverage-excludes.json
@@ -1,0 +1,13 @@
+{
+  "patterns": [
+    "dist/",
+    "node_modules/",
+    "**/*.test.ts",
+    "**/*.test.js",
+    "**/*.spec.ts",
+    "**/*.spec.js",
+    "src/main/**",
+    "src/test-utils/**",
+    "coverage/**"
+  ]
+}

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -25,6 +25,7 @@ function getChangedFiles() {
       .filter(file => !file.includes('.test.') && !file.includes('.spec.'))
       .filter(file => !file.endsWith('.d.ts')) // Exclude TypeScript declaration files
       .filter(file => !file.startsWith('src/main/')) // Exclude main process files (not covered by frontend tests)
+      .filter(file => !file.startsWith('src/test-utils/')) // Exclude test utility files
   }
 
   function tryGitDiff(base) {

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -4,6 +4,9 @@ const fs = require('fs')
 const path = require('path')
 const { execSync } = require('child_process')
 
+// Load shared coverage exclude patterns
+const coverageExcludes = JSON.parse(fs.readFileSync(path.join(__dirname, '../config/coverage-excludes.json'), 'utf-8'))
+
 // Configuration
 const THRESHOLDS = {
   lines: 80,
@@ -17,15 +20,32 @@ function getChangedFiles() {
   const baseBranch = process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : 'origin/main'
 
   function filterSourceFiles(files) {
+    const excludePatterns = coverageExcludes.patterns.map(pattern => {
+      // Convert glob patterns to regex for filtering
+      if (pattern.endsWith('/**')) {
+        return new RegExp(`^${pattern.slice(0, -3).replace(/\*/g, '.*')}`)
+      }
+      if (pattern.includes('*')) {
+        return new RegExp(`^${pattern.replace(/\*/g, '.*')}$`)
+      }
+      return pattern
+    })
+
     return files
       .split('\n')
       .filter(file => file.trim())
       .filter(file => file.startsWith('src/'))
       .filter(file => file.endsWith('.ts') || file.endsWith('.vue'))
-      .filter(file => !file.includes('.test.') && !file.includes('.spec.'))
       .filter(file => !file.endsWith('.d.ts')) // Exclude TypeScript declaration files
-      .filter(file => !file.startsWith('src/main/')) // Exclude main process files (not covered by frontend tests)
-      .filter(file => !file.startsWith('src/test-utils/')) // Exclude test utility files
+      .filter(file => {
+        // Apply shared exclude patterns
+        return !excludePatterns.some(pattern => {
+          if (pattern instanceof RegExp) {
+            return pattern.test(file)
+          }
+          return file.includes(pattern)
+        })
+      })
   }
 
   function tryGitDiff(base) {

--- a/src/components/SetupModal.test.ts
+++ b/src/components/SetupModal.test.ts
@@ -148,8 +148,8 @@ describe('SetupModal Component', () => {
 
   describe('Backup & Restore actions', () => {
     it('renders backup and restore buttons and emits on click', async () => {
-      const backupBtn = wrapper.find('.backup-btn')
-      const restoreBtn = wrapper.find('.restore-btn')
+      const backupBtn = wrapper.find('[data-testid="backup-button"]')
+      const restoreBtn = wrapper.find('[data-testid="restore-button"]')
 
       expect(backupBtn.exists()).toBe(true)
       expect(restoreBtn.exists()).toBe(true)
@@ -163,8 +163,8 @@ describe('SetupModal Component', () => {
 
     it('disables backup and restore while busy', async () => {
       await wrapper.setProps({ isAddingCategory: true })
-      const backupBtn = wrapper.find('.backup-btn')
-      const restoreBtn = wrapper.find('.restore-btn')
+      const backupBtn = wrapper.find('[data-testid="backup-button"]')
+      const restoreBtn = wrapper.find('[data-testid="restore-button"]')
       expect(backupBtn.element).toHaveProperty('disabled', true)
       expect(restoreBtn.element).toHaveProperty('disabled', true)
     })

--- a/src/components/SetupModal.test.ts
+++ b/src/components/SetupModal.test.ts
@@ -24,9 +24,12 @@ describe('SetupModal Component', () => {
         isUpdatingCategory: false,
         isDeletingCategory: false,
         isSettingDefault: false,
-        editingCategoryId: null,
+        editingCategoryId: 0,
         editingCategoryName: '',
-        newCategoryName: ''
+        newCategoryName: '',
+        tempReportingAppButtonText: 'Tempo',
+        tempReportingAppUrl: '',
+        isValidUrl: () => true
       }
     })
   })
@@ -74,6 +77,96 @@ describe('SetupModal Component', () => {
       expect(cancelBtn.exists()).toBe(true)
       expect(saveBtn.text()).toBe('Save')
       expect(cancelBtn.text()).toBe('Cancel')
+    })
+  })
+
+  describe('Reporting App URL validation', () => {
+    it('shows error and invalid class for invalid URL', async () => {
+      await wrapper.setProps({
+        tempReportingAppButtonText: 'Tempo',
+        tempReportingAppUrl: 'http://invalid',
+        isValidUrl: () => false
+      })
+
+      const urlInput = wrapper.find('#reporting-app-url')
+      expect(urlInput.exists()).toBe(true)
+      expect(urlInput.classes()).toContain('invalid-url')
+
+      const error = wrapper.find('.url-error')
+      expect(error.exists()).toBe(true)
+      expect(error.text()).toContain('Please enter a valid URL')
+    })
+
+    it('hides error and class for valid URL', async () => {
+      await wrapper.setProps({
+        tempReportingAppButtonText: 'Tempo',
+        tempReportingAppUrl: 'https://example.com',
+        isValidUrl: () => true
+      })
+
+      const urlInput = wrapper.find('#reporting-app-url')
+      expect(urlInput.exists()).toBe(true)
+      expect(urlInput.classes()).not.toContain('invalid-url')
+
+      const error = wrapper.find('.url-error')
+      expect(error.exists()).toBe(false)
+    })
+
+    it('hides error and class for empty URL regardless of validator', async () => {
+      await wrapper.setProps({
+        tempReportingAppButtonText: 'Tempo',
+        tempReportingAppUrl: '',
+        isValidUrl: () => false
+      })
+
+      const urlInput = wrapper.find('#reporting-app-url')
+      expect(urlInput.exists()).toBe(true)
+      expect(urlInput.classes()).not.toContain('invalid-url')
+      expect(wrapper.find('.url-error').exists()).toBe(false)
+    })
+
+    it('emits updates for reporting app inputs', async () => {
+      await wrapper.setProps({
+        tempReportingAppButtonText: 'Tempo',
+        tempReportingAppUrl: '',
+        isValidUrl: () => true
+      })
+
+      const textInput = wrapper.find('#reporting-button-text')
+      await textInput.setValue('My App')
+      await textInput.trigger('input')
+      expect(wrapper.emitted('updateTempReportingAppButtonText')).toBeTruthy()
+      expect(wrapper.emitted('updateTempReportingAppButtonText')![0]).toEqual(['My App'])
+
+      const urlInput = wrapper.find('#reporting-app-url')
+      await urlInput.setValue('https://foo.example.com')
+      await urlInput.trigger('input')
+      expect(wrapper.emitted('updateTempReportingAppUrl')).toBeTruthy()
+      expect(wrapper.emitted('updateTempReportingAppUrl')![0]).toEqual(['https://foo.example.com'])
+    })
+  })
+
+  describe('Backup & Restore actions', () => {
+    it('renders backup and restore buttons and emits on click', async () => {
+      const backupBtn = wrapper.find('.backup-btn')
+      const restoreBtn = wrapper.find('.restore-btn')
+
+      expect(backupBtn.exists()).toBe(true)
+      expect(restoreBtn.exists()).toBe(true)
+
+      await backupBtn.trigger('click')
+      await restoreBtn.trigger('click')
+
+      expect(wrapper.emitted('backup')).toBeTruthy()
+      expect(wrapper.emitted('restoreBackup')).toBeTruthy()
+    })
+
+    it('disables backup and restore while busy', async () => {
+      await wrapper.setProps({ isAddingCategory: true })
+      const backupBtn = wrapper.find('.backup-btn')
+      const restoreBtn = wrapper.find('.restore-btn')
+      expect(backupBtn.element).toHaveProperty('disabled', true)
+      expect(restoreBtn.element).toHaveProperty('disabled', true)
     })
   })
 

--- a/src/components/SetupModal.vue
+++ b/src/components/SetupModal.vue
@@ -170,8 +170,26 @@
         <div class="setting-group">
           <h4>Backup & Restore</h4>
           <div class="backup-actions">
-            <button class="backup-btn" @click="$emit('backup')" :disabled="isBusy">Backup…</button>
-            <button class="restore-btn" @click="$emit('restoreBackup')" :disabled="isBusy">Restore backup…</button>
+            <button
+              class="backup-btn"
+              data-testid="backup-button"
+              aria-label="Backup workspace"
+              title="Backup workspace"
+              @click="$emit('backup')"
+              :disabled="isBusy"
+            >
+              Backup…
+            </button>
+            <button
+              class="restore-btn"
+              data-testid="restore-button"
+              aria-label="Restore workspace from backup"
+              title="Restore workspace from backup"
+              @click="$emit('restoreBackup')"
+              :disabled="isBusy"
+            >
+              Restore backup…
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/SetupModal.vue
+++ b/src/components/SetupModal.vue
@@ -797,10 +797,20 @@ onUnmounted(() => {
   font-weight: 500;
 }
 
-.backup-btn:hover,
-.restore-btn:hover {
+.backup-btn:not(:disabled):hover,
+.restore-btn:not(:disabled):hover {
   background: var(--primary);
   color: white;
   border-color: var(--primary);
+}
+
+.backup-btn:disabled,
+.restore-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border-color: var(--border-color);
+  pointer-events: none;
 }
 </style>

--- a/src/components/SetupModal.vue
+++ b/src/components/SetupModal.vue
@@ -165,6 +165,15 @@
             </button>
           </div>
         </div>
+
+        <!-- Backup & Restore -->
+        <div class="setting-group">
+          <h4>Backup & Restore</h4>
+          <div class="backup-actions">
+            <button class="backup-btn" @click="$emit('backup')" :disabled="isBusy">Backup…</button>
+            <button class="restore-btn" @click="$emit('restoreBackup')" :disabled="isBusy">Restore backup…</button>
+          </div>
+        </div>
       </div>
 
       <div class="modal-footer">
@@ -261,6 +270,8 @@ const emit = defineEmits<{
   startAddingCategory: []
   updateTempReportingAppButtonText: [text: string]
   updateTempReportingAppUrl: [url: string]
+  backup: []
+  restoreBackup: []
 }>()
 
 // Flag to prevent blur save when cancelling
@@ -748,5 +759,30 @@ onUnmounted(() => {
 .save-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* Backup & Restore */
+.backup-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.backup-btn,
+.restore-btn {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  padding: 10px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-weight: 500;
+}
+
+.backup-btn:hover,
+.restore-btn:hover {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
 }
 </style>

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -221,10 +221,17 @@ export function useSettings() {
     }
 
     applyTheme(currentTheme.value)
-    localStorage.setItem('theme', currentTheme.value)
-    localStorage.setItem('targetWorkHours', targetWorkHours.value.toString())
-    localStorage.setItem('reportingAppButtonText', reportingAppButtonText.value)
-    localStorage.setItem('reportingAppUrl', reportingAppUrl.value)
+
+    // Persist settings with error handling for storage quota/access issues
+    try {
+      localStorage.setItem('theme', currentTheme.value)
+      localStorage.setItem('targetWorkHours', targetWorkHours.value.toString())
+      localStorage.setItem('reportingAppButtonText', reportingAppButtonText.value)
+      localStorage.setItem('reportingAppUrl', reportingAppUrl.value)
+    } catch (error) {
+      console.warn('Failed to persist settings to localStorage:', error)
+      // Continue execution - theme is already applied and in-memory state is updated
+    }
   }
 
   /**
@@ -323,14 +330,19 @@ export function useSettings() {
       reportingAppButtonText.value = buttonText
       reportingAppUrl.value = url
 
-      // Persist
-      localStorage.setItem('theme', currentTheme.value)
-      localStorage.setItem('targetWorkHours', targetWorkHours.value.toString())
-      localStorage.setItem('reportingAppButtonText', reportingAppButtonText.value)
-      localStorage.setItem('reportingAppUrl', reportingAppUrl.value)
-
       // Apply theme now
       applyTheme(currentTheme.value)
+
+      // Persist with error handling for storage quota/access issues
+      try {
+        localStorage.setItem('theme', currentTheme.value)
+        localStorage.setItem('targetWorkHours', targetWorkHours.value.toString())
+        localStorage.setItem('reportingAppButtonText', reportingAppButtonText.value)
+        localStorage.setItem('reportingAppUrl', reportingAppUrl.value)
+      } catch (error) {
+        console.warn('Failed to persist restored settings to localStorage:', error)
+        // Continue execution - theme is already applied and in-memory state is updated
+      }
 
       // Sync temps
       initializeTempSettings()

--- a/src/main/backupUtils.test.ts
+++ b/src/main/backupUtils.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeCategories, normalizeTaskRecords } from './backupUtils'
+
+describe('backupUtils - normalizeCategories', () => {
+  it('dedupes categories by trimmed name and keeps a single default', () => {
+    const input = [
+      { name: 'Dev', is_default: true },
+      { name: 'Dev ' },
+      { name: 'Personal', is_default: true },
+      { name: 'Meetings' },
+      { name: '  ' },
+      { name: null }
+    ]
+
+    const out = normalizeCategories(input as any)
+    // Should keep Dev, Personal, Meetings (unique names)
+    expect(out.map(c => c.name)).toEqual(['Dev', 'Personal', 'Meetings'])
+    // First default wins: Dev should be default, others false
+    expect(out).toEqual([
+      { name: 'Dev', is_default: true },
+      { name: 'Personal', is_default: false },
+      { name: 'Meetings', is_default: false }
+    ])
+  })
+
+  it('assigns first as default when none provided', () => {
+    const input = [{ name: 'A' }, { name: 'B' }]
+    const out = normalizeCategories(input as any)
+    expect(out).toEqual([
+      { name: 'A', is_default: true },
+      { name: 'B', is_default: false }
+    ])
+  })
+})
+
+describe('backupUtils - normalizeTaskRecords', () => {
+  it('validates task_type and defaults to normal when invalid', () => {
+    const input = [
+      { category_name: 'Dev', task_name: 'T', start_time: '10:00', date: '2024-01-01', task_type: 'weird' }
+    ]
+    const out = normalizeTaskRecords(input as any)
+    expect(out[0].task_type).toBe('normal')
+  })
+
+  it('skips invalid/missing required fields', () => {
+    const input = [
+      { category_name: '', task_name: 'T', start_time: '10:00', date: '2024-01-01', task_type: 'normal' },
+      { category_name: 'Dev', task_name: '', start_time: '10:00', date: '2024-01-01', task_type: 'normal' },
+      { category_name: 'Dev', task_name: 'T', start_time: '', date: '2024-01-01', task_type: 'normal' },
+      { category_name: 'Dev', task_name: 'T', start_time: '10:00', date: '', task_type: 'normal' },
+      { category_name: 'Dev', task_name: 'T', start_time: '10:00', date: '2024-01-01', task_type: 'normal' }
+    ]
+    const out = normalizeTaskRecords(input as any)
+    expect(out).toHaveLength(1)
+    expect(out[0].category_name).toBe('Dev')
+  })
+
+  it('keeps only the first END record per date', () => {
+    const input = [
+      { category_name: 'Dev', task_name: 'End', start_time: '18:00', date: '2024-01-01', task_type: 'end' },
+      { category_name: 'Dev', task_name: 'End 2', start_time: '19:00', date: '2024-01-01', task_type: 'end' },
+      { category_name: 'Dev', task_name: 'End2 day2', start_time: '19:00', date: '2024-01-02', task_type: 'end' }
+    ]
+    const out = normalizeTaskRecords(input as any)
+    const ends = out.filter(r => r.task_type === 'end')
+    expect(ends).toHaveLength(2)
+    // Preserve first end per day
+    expect(ends[0]).toMatchObject({ date: '2024-01-01', task_name: 'End' })
+    expect(ends[1]).toMatchObject({ date: '2024-01-02', task_name: 'End2 day2' })
+  })
+
+  it('preserves created_at if provided', () => {
+    const input = [
+      {
+        category_name: 'Dev',
+        task_name: 'T',
+        start_time: '10:00',
+        date: '2024-01-01',
+        task_type: 'normal',
+        created_at: '2024-01-01T10:00:00Z'
+      }
+    ]
+    const out = normalizeTaskRecords(input as any)
+    expect(out[0].created_at).toBe('2024-01-01T10:00:00Z')
+  })
+})

--- a/src/main/backupUtils.ts
+++ b/src/main/backupUtils.ts
@@ -1,0 +1,77 @@
+import { TASK_TYPES, TASK_TYPE_END } from '../shared/types'
+
+export interface RawCategory {
+  name?: unknown
+  is_default?: unknown
+}
+
+export interface NormalizedCategory {
+  name: string
+  is_default: boolean
+}
+
+export interface RawTaskRecord {
+  category_name?: unknown
+  task_name?: unknown
+  start_time?: unknown
+  date?: unknown
+  task_type?: unknown
+  created_at?: unknown
+}
+
+export interface NormalizedTaskRecord {
+  category_name: string
+  task_name: string
+  start_time: string
+  date: string
+  task_type: string
+  created_at?: string
+}
+
+export function normalizeCategories(categories: any[]): NormalizedCategory[] {
+  const seen = new Set<string>()
+  const deduped: NormalizedCategory[] = []
+  for (const c of categories as RawCategory[]) {
+    const name = String((c?.name as any) ?? '').trim()
+    if (!name || seen.has(name)) continue
+    seen.add(name)
+    const isDefault = Boolean(c?.is_default)
+    deduped.push({ name, is_default: isDefault })
+  }
+
+  // Ensure a single default: prefer first marked default, otherwise first item if available
+  let defaultName: string | null = null
+  for (const c of deduped) {
+    if (c.is_default) {
+      defaultName = c.name
+      break
+    }
+  }
+  if (!defaultName && deduped.length > 0) {
+    defaultName = deduped[0].name
+  }
+  return deduped.map(c => ({ name: c.name, is_default: defaultName === c.name }))
+}
+
+export function normalizeTaskRecords(records: any[]): NormalizedTaskRecord[] {
+  const allowedTypes = new Set<string>((TASK_TYPES as unknown as string[]) || [])
+  const endDates = new Set<string>()
+  const out: NormalizedTaskRecord[] = []
+  for (const r of records as RawTaskRecord[]) {
+    const category_name = String((r?.category_name as any) ?? '').trim()
+    const task_name = String((r?.task_name as any) ?? '').trim()
+    const start_time = String((r?.start_time as any) ?? '').trim()
+    const date = String((r?.date as any) ?? '').trim()
+    let task_type = String((r?.task_type as any) ?? 'normal').toLowerCase()
+    if (!allowedTypes.has(task_type)) task_type = 'normal'
+    if (!category_name || !task_name || !start_time || !date) continue
+    if (task_type === TASK_TYPE_END) {
+      if (endDates.has(date)) continue
+      endDates.add(date)
+    }
+    const created_atVal = r?.created_at
+    const created_at = created_atVal == null ? undefined : String(created_atVal)
+    out.push({ category_name, task_name, start_time, date, task_type, created_at })
+  }
+  return out
+}

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import type { TaskRecordInsert, TaskRecordUpdate } from '../shared/types'
+import type { TaskRecordInsert, TaskRecordUpdate, SettingsSnapshot, BackupResult, RestoreResult } from '../shared/types'
 
 contextBridge.exposeInMainWorld('electronAPI', {
   // Application info
@@ -20,7 +20,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   deleteTaskRecord: (id: number) => ipcRenderer.invoke('db:delete-task-record', id),
   debugAll: () => ipcRenderer.invoke('db:debug-all'),
   // Backup & restore
-  backupApp: (settings: any): Promise<{ ok: boolean; error?: string }> => ipcRenderer.invoke('app:backup', settings),
-  restoreApp: (): Promise<{ ok: boolean; settings?: any; error?: string; cancelled?: boolean }> =>
-    ipcRenderer.invoke('app:restore')
+  backupApp: (settings: SettingsSnapshot): Promise<BackupResult> => ipcRenderer.invoke('app:backup', settings),
+  restoreApp: (): Promise<RestoreResult> => ipcRenderer.invoke('app:restore')
 })

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -18,5 +18,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getTaskRecordsByDate: (date: string) => ipcRenderer.invoke('db:get-task-records-by-date', date),
   updateTaskRecord: (id: number, record: TaskRecordUpdate) => ipcRenderer.invoke('db:update-task-record', id, record),
   deleteTaskRecord: (id: number) => ipcRenderer.invoke('db:delete-task-record', id),
-  debugAll: () => ipcRenderer.invoke('db:debug-all')
+  debugAll: () => ipcRenderer.invoke('db:debug-all'),
+  // Backup & restore
+  backupApp: (settings: any): Promise<{ ok: boolean; error?: string }> => ipcRenderer.invoke('app:backup', settings),
+  restoreApp: (): Promise<{ ok: boolean; settings?: any; error?: string; cancelled?: boolean }> =>
+    ipcRenderer.invoke('app:restore')
 })

--- a/src/main/restore.integration.test.ts
+++ b/src/main/restore.integration.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Hoisted state and inline mocks to avoid TDZ issues under Node 24
+const h = vi.hoisted(() => {
+  const electronState = {
+    handlers: {} as Record<string, Function>,
+    showOpenDialogMock: vi.fn(),
+    showSaveDialogMock: vi.fn(),
+    showErrorBoxMock: vi.fn()
+  }
+  const fsState = {
+    readFileMock: vi.fn(),
+    writeFileMock: vi.fn()
+  }
+  const dbState = {
+    calls: {} as Record<string, any[][]>,
+    selectCategories: [] as any[],
+    selectTaskRecords: [] as any[]
+  }
+  return { electronState, fsState, dbState }
+})
+
+vi.mock('electron', () => {
+  const { electronState } = h
+  return {
+    app: {
+      whenReady: () => Promise.resolve(),
+      isPackaged: false,
+      on: () => {}
+    },
+    BrowserWindow: class {
+      static getAllWindows() {
+        return []
+      }
+      loadURL() {}
+      loadFile() {}
+      webContents = { openDevTools() {} }
+      constructor(_: any) {}
+    },
+    ipcMain: {
+      handle: (channel: string, handler: Function) => {
+        h.electronState.handlers[channel] = handler
+      }
+    },
+    shell: { openExternal() {} },
+    dialog: {
+      showOpenDialog: (...args: any[]) => h.electronState.showOpenDialogMock(...args),
+      showSaveDialog: (...args: any[]) => h.electronState.showSaveDialogMock(...args),
+      showErrorBox: (...args: any[]) => h.electronState.showErrorBoxMock(...args)
+    }
+  }
+})
+
+vi.mock('fs', () => {
+  const { fsState } = h
+  const promises = {
+    readFile: fsState.readFileMock,
+    writeFile: fsState.writeFileMock
+  }
+  return { promises, default: { promises } }
+})
+
+vi.mock('./database', () => {
+  const prepare = (sql: string) => {
+    const obj: any = {
+      run: (...args: any[]) => {
+        if (!h.dbState.calls[sql]) h.dbState.calls[sql] = []
+        h.dbState.calls[sql].push(args)
+        return {}
+      },
+      all: () => [],
+      get: () => undefined
+    }
+    if (/SELECT/i.test(sql) && /FROM\s+categories/i.test(sql)) {
+      obj.all = () => h.dbState.selectCategories
+    }
+    if (/SELECT/i.test(sql) && /FROM\s+task_records/i.test(sql)) {
+      obj.all = () => h.dbState.selectTaskRecords
+    }
+    return obj
+  }
+  const transaction = (fn: Function) => (arg: any) => fn(arg)
+  const getDbCalls = () => h.dbState.calls
+  return { dbService: { db: { prepare, transaction } }, getDbCalls }
+})
+
+// Load main to register handlers with the mocks - use dynamic import in test setup
+let mainModule: any = null
+
+// Avoid requiring the mocked modules directly to prevent CJS interop quirks
+
+describe('Restore integration (normalized insertions)', () => {
+  beforeEach(async () => {
+    // Load main module to register handlers if not already loaded
+    if (!mainModule) {
+      mainModule = await import('./main')
+    }
+
+    // Reset mock state, but keep registered handlers
+    h.electronState.showOpenDialogMock.mockReset()
+    h.electronState.showSaveDialogMock.mockReset()
+    h.electronState.showErrorBoxMock.mockReset()
+    for (const k of Object.keys(h.dbState.calls)) delete h.dbState.calls[k]
+    h.dbState.selectCategories = []
+    h.dbState.selectTaskRecords = []
+    h.fsState.readFileMock.mockReset()
+    h.fsState.writeFileMock.mockReset()
+  })
+
+  it('inserts deduped categories and skips duplicate END per day without errors', async () => {
+    const backup = {
+      version: 1,
+      settings: {},
+      database: {
+        categories: [
+          { name: 'Dev', is_default: true },
+          { name: 'Dev' },
+          { name: 'Personal', is_default: true },
+          { name: 'Meetings' }
+        ],
+        task_records: [
+          { category_name: 'Dev', task_name: 'Start', start_time: '09:00', date: '2024-01-01', task_type: 'normal' },
+          { category_name: 'Dev', task_name: 'End', start_time: '18:00', date: '2024-01-01', task_type: 'end' },
+          {
+            category_name: 'Dev',
+            task_name: 'End duplicate',
+            start_time: '19:00',
+            date: '2024-01-01',
+            task_type: 'end'
+          },
+          {
+            category_name: 'Personal',
+            task_name: 'End day2',
+            start_time: '18:00',
+            date: '2024-01-02',
+            task_type: 'end'
+          },
+          {
+            category_name: 'Meetings',
+            task_name: 'Weird type',
+            start_time: '11:00',
+            date: '2024-01-03',
+            task_type: 'unknown'
+          }
+        ]
+      }
+    }
+
+    h.electronState.showOpenDialogMock.mockResolvedValue({ canceled: false, filePaths: ['dummy.json'] })
+    h.fsState.readFileMock.mockResolvedValue(JSON.stringify(backup))
+
+    const restoreHandler = h.electronState.handlers['app:restore']
+    expect(typeof restoreHandler).toBe('function')
+    const res = await restoreHandler()
+    expect(res?.ok).toBe(true)
+
+    const sqlCalls = h.dbState.calls
+    expect(sqlCalls['DELETE FROM task_records']).toBeTruthy()
+    expect(sqlCalls['DELETE FROM categories']).toBeTruthy()
+
+    const catInserts = sqlCalls['INSERT INTO categories (name, is_default) VALUES (?, ?)'] || []
+    expect(catInserts.length).toBe(3)
+    const defaultCount = catInserts.reduce((acc, args) => acc + (args[1] ? 1 : 0), 0)
+    expect(defaultCount).toBe(1)
+
+    const recInsert =
+      sqlCalls[
+        'INSERT INTO task_records (category_name, task_name, start_time, date, task_type)\n         VALUES (?, ?, ?, ?, ?)'
+      ] || []
+    const recInsertWithCreated =
+      sqlCalls[
+        'INSERT INTO task_records (category_name, task_name, start_time, date, task_type, created_at)\n         VALUES (?, ?, ?, ?, ?, ?)'
+      ] || []
+    const allRecInserts = [...recInsert, ...recInsertWithCreated]
+    expect(allRecInserts.length).toBe(4)
+    const endDateCounts: Record<string, number> = {}
+    for (const args of allRecInserts) {
+      const date = args[3]
+      const type = args[4]
+      if (type === 'end') endDateCounts[date] = (endDateCounts[date] || 0) + 1
+    }
+    expect(endDateCounts['2024-01-01']).toBe(1)
+    expect(endDateCounts['2024-01-02']).toBe(1)
+
+    expect(h.electronState.showErrorBoxMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('Backup integration', () => {
+  beforeEach(async () => {
+    // Load main module to register handlers if not already loaded
+    if (!mainModule) {
+      mainModule = await import('./main')
+    }
+  })
+
+  it('returns { cancelled: true } when user cancels save dialog', async () => {
+    h.electronState.showSaveDialogMock.mockReset()
+    h.electronState.showSaveDialogMock.mockResolvedValue({ canceled: true, filePath: undefined })
+
+    const backupHandler = h.electronState.handlers['app:backup']
+    expect(typeof backupHandler).toBe('function')
+
+    const res = await backupHandler({}, { theme: 'dark' })
+    expect(res).toEqual({ cancelled: true })
+    expect(h.fsState.writeFileMock.mock.calls.length).toBe(0)
+  })
+
+  it('creates backup JSON with expected shape', async () => {
+    h.electronState.showSaveDialogMock.mockReset()
+    h.electronState.showSaveDialogMock.mockResolvedValue({ canceled: false, filePath: 'backup.json' })
+
+    h.dbState.selectCategories = [{ id: 1, name: 'Dev', is_default: 1, created_at: '2024-01-01T00:00:00Z' }]
+    h.dbState.selectTaskRecords = [
+      {
+        id: 1,
+        category_name: 'Dev',
+        task_name: 'Start',
+        start_time: '09:00',
+        date: '2024-01-01',
+        task_type: 'normal',
+        created_at: '2024-01-01T09:00:00Z'
+      }
+    ]
+
+    h.fsState.writeFileMock.mockReset()
+
+    const backupHandler = h.electronState.handlers['app:backup']
+    expect(typeof backupHandler).toBe('function')
+
+    const res = await backupHandler(
+      {},
+      { theme: 'dark', targetWorkHours: 7, reportingAppButtonText: 'Tempo', reportingAppUrl: 'https://test' }
+    )
+    expect(res).toEqual({ ok: true })
+    expect(h.fsState.writeFileMock).toHaveBeenCalledTimes(1)
+    const args = h.fsState.writeFileMock.mock.calls[0]
+    expect(args[0]).toBe('backup.json')
+    const json = JSON.parse(args[1])
+    expect(json.version).toBe(1)
+    expect(json.settings).toMatchObject({
+      theme: 'dark',
+      targetWorkHours: 7,
+      reportingAppButtonText: 'Tempo',
+      reportingAppUrl: 'https://test'
+    })
+    expect(Array.isArray(json.database.categories)).toBe(true)
+    expect(Array.isArray(json.database.task_records)).toBe(true)
+    expect(json.database.categories.length).toBe(1)
+    expect(json.database.task_records.length).toBe(1)
+  })
+})

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -103,6 +103,8 @@
       @add-category="addCategoryWrapper"
       @cancel-adding-category="cancelAddingCategory"
       @start-adding-category="startAddingCategory"
+      @backup="backupApp"
+      @restore-backup="restoreBackup"
     />
 
     <!-- Toast notification -->
@@ -427,6 +429,62 @@ const closeSetupModal = () => {
 const saveSettings = () => {
   saveSettingsComposable()
   closeSetupModal()
+}
+
+// Backup & Restore handlers
+const backupApp = async () => {
+  if (!window?.electronAPI || typeof window.electronAPI.backupApp !== 'function') {
+    showToastMessage('Backup not available (IPC unavailable)', 'error')
+    return
+  }
+  const settings = {
+    theme: currentTheme.value,
+    targetWorkHours: targetWorkHours.value,
+    reportingAppButtonText: reportingAppButtonText.value,
+    reportingAppUrl: reportingAppUrl.value
+  }
+  try {
+    const res = await window.electronAPI.backupApp(settings)
+    if (res?.ok) {
+      showToastMessage('Backup saved successfully', 'success')
+    } else if (res?.error) {
+      showToastMessage(`Backup failed: ${res.error}`, 'error')
+    }
+  } catch (e) {
+    showToastMessage('Backup failed', 'error')
+  }
+}
+
+const restoreBackup = async () => {
+  if (!window?.electronAPI || typeof window.electronAPI.restoreApp !== 'function') {
+    showToastMessage('Restore not available (IPC unavailable)', 'error')
+    return
+  }
+  try {
+    const res = await window.electronAPI.restoreApp()
+    if (res?.ok) {
+      // Apply restored settings if provided
+      const restored = res.settings || {}
+      try {
+        // Apply and persist restored settings
+        const { applyRestoredSettings } = useSettings()
+        applyRestoredSettings(restored)
+      } catch (e) {
+        // Non-fatal; settings can be adjusted manually
+        console.warn('Failed to apply restored settings:', e)
+      }
+      // Reload data
+      await loadCategoriesWrapper()
+      await loadTaskRecordsWrapper()
+      showToastMessage('Restore completed successfully', 'success')
+    } else if (res?.cancelled) {
+      // user cancelled - no toast necessary
+    } else {
+      showToastMessage(`Restore failed${res?.error ? `: ${res.error}` : ''}`, 'error')
+    }
+  } catch (e) {
+    showToastMessage('Restore failed', 'error')
+  }
 }
 
 // Category management functions - wrappers with UI state management

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -42,13 +42,35 @@ export type TaskRecordWithId = TaskRecord & { id: number }
 export type TaskRecordInsert = Omit<TaskRecord, 'id' | 'created_at'>
 export type TaskRecordUpdate = Partial<Omit<TaskRecord, 'id' | 'created_at' | 'task_type'>>
 
+// Snapshot of user-configurable settings used for backup/restore
+export interface SettingsSnapshot {
+  theme: 'light' | 'dark' | 'auto'
+  targetWorkHours: number
+  reportingAppButtonText: string
+  reportingAppUrl: string
+}
+
+// IPC result types for backup/restore flows
+export interface BackupResult {
+  ok?: boolean
+  cancelled?: boolean
+  error?: string
+}
+
+export interface RestoreResult {
+  ok?: boolean
+  cancelled?: boolean
+  error?: string
+  settings?: Partial<SettingsSnapshot>
+}
+
 export interface ElectronAPI {
   // Application info
   getVersion: () => Promise<string>
   openExternalUrl: (url: string) => Promise<boolean>
   // Backup & Restore
-  backupApp?: (settings: any) => Promise<{ ok: boolean; error?: string }>
-  restoreApp?: () => Promise<{ ok: boolean; settings?: any; error?: string; cancelled?: boolean }>
+  backupApp?: (settings: SettingsSnapshot) => Promise<BackupResult>
+  restoreApp?: () => Promise<RestoreResult>
   // Database operations
   getCategories: () => Promise<Category[]>
   addCategory: (name: string) => Promise<Category>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -46,6 +46,9 @@ export interface ElectronAPI {
   // Application info
   getVersion: () => Promise<string>
   openExternalUrl: (url: string) => Promise<boolean>
+  // Backup & Restore
+  backupApp?: (settings: any) => Promise<{ ok: boolean; error?: string }>
+  restoreApp?: () => Promise<{ ok: boolean; settings?: any; error?: string; cancelled?: boolean }>
   // Database operations
   getCategories: () => Promise<Category[]>
   addCategory: (name: string) => Promise<Category>

--- a/src/test-utils/mainMocks.ts
+++ b/src/test-utils/mainMocks.ts
@@ -73,7 +73,10 @@ const prepare = (sql: string) => {
   return obj
 }
 
-const transaction = (fn: Function) => (arg: any) => fn(arg)
+const transaction =
+  (fn: Function) =>
+  (...args: any[]) =>
+    fn(...args)
 
 export const databaseMockFactory = () => ({
   dbService: {

--- a/src/test-utils/mainMocks.ts
+++ b/src/test-utils/mainMocks.ts
@@ -1,0 +1,100 @@
+import { vi } from 'vitest'
+
+// Electron mock state and factory
+const electronState = {
+  handlers: {} as Record<string, Function>,
+  showOpenDialogMock: vi.fn(),
+  showSaveDialogMock: vi.fn(),
+  showErrorBoxMock: vi.fn()
+}
+
+export const electronMockFactory = () => ({
+  app: {
+    whenReady: () => Promise.resolve(),
+    isPackaged: false,
+    on: vi.fn()
+  },
+  BrowserWindow: class {
+    loadURL = vi.fn()
+    loadFile = vi.fn()
+    webContents = { openDevTools: vi.fn() }
+    constructor(_: any) {}
+  },
+  ipcMain: {
+    handle: (channel: string, fn: Function) => {
+      electronState.handlers[channel] = fn
+    }
+  },
+  shell: { openExternal: vi.fn() },
+  dialog: {
+    showOpenDialog: (...args: any[]) => electronState.showOpenDialogMock(...args),
+    showSaveDialog: (...args: any[]) => electronState.showSaveDialogMock(...args),
+    showErrorBox: (...args: any[]) => electronState.showErrorBoxMock(...args)
+  },
+  __handlers: electronState.handlers
+})
+
+// FS mock state and factory
+const fsState = {
+  readFileMock: vi.fn(),
+  writeFileMock: vi.fn()
+}
+
+export const fsMockFactory = () => ({
+  promises: {
+    readFile: (...args: any[]) => fsState.readFileMock(...args),
+    writeFile: (...args: any[]) => fsState.writeFileMock(...args)
+  }
+})
+
+// Database mock state and factory
+const dbState = {
+  calls: {} as Record<string, any[][]>,
+  selectCategories: [] as any[],
+  selectTaskRecords: [] as any[]
+}
+
+const prepare = (sql: string) => {
+  const obj: any = {
+    run: (...args: any[]) => {
+      if (!dbState.calls[sql]) dbState.calls[sql] = []
+      dbState.calls[sql].push(args)
+      return {}
+    },
+    all: vi.fn(),
+    get: vi.fn()
+  }
+  if (/SELECT/i.test(sql) && /FROM\s+categories/i.test(sql)) {
+    obj.all = vi.fn(() => dbState.selectCategories)
+  }
+  if (/SELECT/i.test(sql) && /FROM\s+task_records/i.test(sql)) {
+    obj.all = vi.fn(() => dbState.selectTaskRecords)
+  }
+  return obj
+}
+
+const transaction = (fn: Function) => (arg: any) => fn(arg)
+
+export const databaseMockFactory = () => ({
+  dbService: {
+    db: { prepare, transaction }
+  },
+  getDbCalls: () => dbState.calls
+})
+
+export const resetMainMocks = () => {
+  // Electron
+  electronState.showOpenDialogMock.mockReset()
+  electronState.showSaveDialogMock.mockReset()
+  electronState.showErrorBoxMock.mockReset()
+  for (const k of Object.keys(electronState.handlers)) delete electronState.handlers[k]
+  // FS
+  fsState.readFileMock.mockReset()
+  fsState.writeFileMock.mockReset()
+  // DB
+  for (const k of Object.keys(dbState.calls)) delete dbState.calls[k]
+  dbState.selectCategories = []
+  dbState.selectTaskRecords = []
+}
+
+export const mainMockState = { electron: electronState, fs: fsState, db: dbState }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
+import coverageExcludes from './config/coverage-excludes.json'
 
 export default defineConfig({
   plugins: [vue()],
@@ -15,17 +16,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],
       reportsDirectory: './coverage',
-      exclude: [
-        'dist/',
-        'node_modules/',
-        '**/*.test.ts',
-        '**/*.test.js',
-        '**/*.spec.ts',
-        '**/*.spec.js',
-        'src/main/**', // Exclude Electron main process files
-        'src/test-utils/**', // Exclude test utility files
-        'coverage/**'
-      ]
+      exclude: coverageExcludes.patterns
       // Global thresholds removed - using per-file check in scripts/check-coverage.js
     }
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,8 +23,9 @@ export default defineConfig({
         '**/*.spec.ts',
         '**/*.spec.js',
         'src/main/**', // Exclude Electron main process files
+        'src/test-utils/**', // Exclude test utility files
         'coverage/**'
-      ],
+      ]
       // Global thresholds removed - using per-file check in scripts/check-coverage.js
     }
   },


### PR DESCRIPTION
…ettings

- Introduced "Backup & Restore" actions in Setup Modal.
- Implemented Electron IPC handlers for saving and loading app backups.
- Added settings and database snapshot support for backups.
- Applied restored settings with validation and theme adjustments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Backup & Restore in Settings: save/load JSON backups via OS dialogs, with success/error/cancel toasts; buttons disabled while busy. Restores apply validated settings and refresh app data so the UI reflects the restored configuration.
  - Reporting App fields added to Settings with URL validation and editable button text.

- **Tests**
  - Extensive unit, integration, and normalization tests for backup/restore flows, validation, persistence, and UI wiring.

- **Documentation**
  - Accessibility checklist item added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->