### PR TITLE
feat(eviction-settings): implement old task entries eviction function…

### DIFF
--- a/src/components/SetupModal.vue
+++ b/src/components/SetupModal.vue
@@ -166,6 +166,45 @@
           </div>
         </div>
 
+        <!-- Old Entries Cleanup -->
+        <div class="setting-group">
+          <h4>Old Entries Cleanup</h4>
+          <div class="eviction-settings">
+            <div class="eviction-enabled-setting">
+              <label class="checkbox-container">
+                <input
+                  type="checkbox"
+                  :checked="tempEvictionEnabled"
+                  @change="$emit('updateTempEvictionEnabled', ($event.target as HTMLInputElement).checked)"
+                  class="eviction-checkbox"
+                />
+                <span class="checkmark"></span>
+                Enable old entries cleanup
+              </label>
+            </div>
+            <div class="eviction-days-setting" :class="{ disabled: !tempEvictionEnabled }">
+              <label for="eviction-days">Days of history to keep:</label>
+              <input
+                type="number"
+                id="eviction-days"
+                :value="tempEvictionDaysToKeep"
+                @input="onEvictionDaysInput($event)"
+                min="30"
+                max="3650"
+                step="1"
+                class="eviction-days-input"
+                :class="{ 'invalid-input': tempEvictionDaysToKeep < 30 || tempEvictionDaysToKeep > 3650 }"
+                :disabled="!tempEvictionEnabled"
+              />
+              <span class="days-label">days</span>
+            </div>
+            <div class="eviction-help-text">
+              Minimum 30 days to prevent accidental data loss. When enabled, old task entries are automatically removed
+              after creating an "End" task.
+            </div>
+          </div>
+        </div>
+
         <!-- Backup & Restore -->
         <div class="setting-group">
           <h4>Backup & Restore</h4>
@@ -267,6 +306,18 @@ const props = defineProps({
   isValidUrl: {
     type: Function as PropType<(url: string) => boolean>,
     required: true
+  },
+  tempEvictionEnabled: {
+    type: Boolean,
+    required: true
+  },
+  tempEvictionDaysToKeep: {
+    type: Number,
+    required: true
+  },
+  isValidEvictionDaysToKeep: {
+    type: Function as PropType<(value: unknown) => boolean>,
+    required: true
   }
 })
 
@@ -288,6 +339,8 @@ const emit = defineEmits<{
   startAddingCategory: []
   updateTempReportingAppButtonText: [text: string]
   updateTempReportingAppUrl: [url: string]
+  updateTempEvictionEnabled: [enabled: boolean]
+  updateTempEvictionDaysToKeep: [days: number]
   backup: []
   restoreBackup: []
 }>()
@@ -307,6 +360,12 @@ function onTargetHoursInput(e: Event) {
   const raw = parseFloat((e.target as HTMLInputElement).value)
   const clamped = Number.isFinite(raw) ? Math.min(24, Math.max(1, raw)) : 1
   emit('updateTempTargetWorkHours', clamped)
+}
+
+function onEvictionDaysInput(e: Event) {
+  const raw = parseInt((e.target as HTMLInputElement).value, 10)
+  const clamped = Number.isFinite(raw) ? Math.min(3650, Math.max(30, raw)) : 30
+  emit('updateTempEvictionDaysToKeep', clamped)
 }
 
 function handleEscapeCancel() {
@@ -812,5 +871,97 @@ onUnmounted(() => {
   color: var(--text-secondary);
   border-color: var(--border-color);
   pointer-events: none;
+}
+
+/* Eviction Settings */
+.eviction-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.eviction-enabled-setting {
+  display: flex;
+  align-items: center;
+}
+
+.checkbox-container {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.eviction-checkbox {
+  margin-right: 12px;
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.checkmark {
+  display: none;
+}
+
+.eviction-days-setting {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  transition: opacity 0.2s ease;
+}
+
+.eviction-days-setting.disabled {
+  opacity: 0.5;
+}
+
+.eviction-days-setting label {
+  color: var(--text-primary);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.eviction-days-input {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 8px 12px;
+  color: var(--text-primary);
+  width: 80px;
+  text-align: center;
+  transition: all 0.2s ease;
+}
+
+.eviction-days-input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(87, 189, 175, 0.1);
+}
+
+.eviction-days-input:disabled {
+  cursor: not-allowed;
+  background: var(--border-color);
+  color: var(--text-muted);
+}
+
+.eviction-days-input.invalid-input {
+  border-color: #e74c3c;
+  box-shadow: 0 0 0 2px rgba(231, 76, 60, 0.1);
+}
+
+.days-label {
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.eviction-help-text {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 12px;
+  background: var(--bg-secondary);
+  border-radius: 6px;
+  border-left: 3px solid var(--primary);
 }
 </style>

--- a/src/composables/useSettings.test.ts
+++ b/src/composables/useSettings.test.ts
@@ -908,4 +908,178 @@ describe('useSettings', () => {
       global.document = originalDocument
     })
   })
+
+  describe('eviction settings', () => {
+    it('should load eviction settings from localStorage with defaults', () => {
+      const TestComponent = defineComponent({
+        setup() {
+          const { evictionEnabled, evictionDaysToKeep } = useSettings()
+          return { evictionEnabled, evictionDaysToKeep }
+        },
+        template: '<div></div>'
+      })
+
+      const wrapper = mount(TestComponent)
+
+      // Should use defaults
+      expect(wrapper.vm.evictionEnabled).toBe(true)
+      expect(wrapper.vm.evictionDaysToKeep).toBe(180)
+
+      wrapper.unmount()
+    })
+
+    it('should load eviction settings from localStorage with stored values', () => {
+      localStorageMock['evictionEnabled'] = 'false'
+      localStorageMock['evictionDaysToKeep'] = '365'
+
+      const TestComponent = defineComponent({
+        setup() {
+          const { evictionEnabled, evictionDaysToKeep } = useSettings()
+          return { evictionEnabled, evictionDaysToKeep }
+        },
+        template: '<div></div>'
+      })
+
+      const wrapper = mount(TestComponent)
+
+      expect(wrapper.vm.evictionEnabled).toBe(false)
+      expect(wrapper.vm.evictionDaysToKeep).toBe(365)
+
+      wrapper.unmount()
+    })
+
+    it('should validate eviction days with minimum 30 days', () => {
+      const { isValidEvictionDaysToKeep } = useSettings()
+
+      expect(isValidEvictionDaysToKeep(29)).toBe(false)
+      expect(isValidEvictionDaysToKeep(30)).toBe(true)
+      expect(isValidEvictionDaysToKeep(180)).toBe(true)
+      expect(isValidEvictionDaysToKeep(3650)).toBe(true)
+      expect(isValidEvictionDaysToKeep(3651)).toBe(false)
+      expect(isValidEvictionDaysToKeep('invalid')).toBe(false)
+      expect(isValidEvictionDaysToKeep(null)).toBe(false)
+      expect(isValidEvictionDaysToKeep(undefined)).toBe(false)
+    })
+
+    it('should save eviction settings to localStorage', () => {
+      const TestComponent = defineComponent({
+        setup() {
+          const { tempEvictionEnabled, tempEvictionDaysToKeep, saveSettings } = useSettings()
+          return { tempEvictionEnabled, tempEvictionDaysToKeep, saveSettings }
+        },
+        template: '<div></div>'
+      })
+
+      const wrapper = mount(TestComponent)
+
+      wrapper.vm.tempEvictionEnabled = false
+      wrapper.vm.tempEvictionDaysToKeep = 90
+      wrapper.vm.saveSettings()
+
+      expect(setItemSpy).toHaveBeenCalledWith('evictionEnabled', 'false')
+      expect(setItemSpy).toHaveBeenCalledWith('evictionDaysToKeep', '90')
+
+      wrapper.unmount()
+    })
+
+    it('should use default values for invalid eviction days', () => {
+      localStorageMock['evictionDaysToKeep'] = '15' // Below minimum
+
+      const TestComponent = defineComponent({
+        setup() {
+          const { evictionDaysToKeep } = useSettings()
+          return { evictionDaysToKeep }
+        },
+        template: '<div></div>'
+      })
+
+      const wrapper = mount(TestComponent)
+
+      // Should fallback to default
+      expect(wrapper.vm.evictionDaysToKeep).toBe(180)
+
+      wrapper.unmount()
+    })
+
+    it('should handle invalid eviction days in saveSettings', () => {
+      const TestComponent = defineComponent({
+        setup() {
+          const { tempEvictionDaysToKeep, evictionDaysToKeep, saveSettings } = useSettings()
+          return { tempEvictionDaysToKeep, evictionDaysToKeep, saveSettings }
+        },
+        template: '<div></div>'
+      })
+
+      const wrapper = mount(TestComponent)
+
+      // Set invalid value
+      wrapper.vm.tempEvictionDaysToKeep = 15 // Below minimum
+      wrapper.vm.saveSettings()
+
+      // Should keep the default value
+      expect(wrapper.vm.evictionDaysToKeep).toBe(180)
+
+      wrapper.unmount()
+    })
+
+    it('should include eviction settings in sanitizeRestoredSettings', () => {
+      const TestComponent = defineComponent({
+        setup() {
+          const settings = useSettings()
+          return settings
+        },
+        template: '<div></div>'
+      })
+
+      const wrapper = mount(TestComponent)
+
+      // Test with valid eviction settings
+      const mockSettings = {
+        theme: 'dark',
+        targetWorkHours: 8,
+        reportingAppButtonText: 'Test',
+        reportingAppUrl: 'https://example.com',
+        evictionEnabled: false,
+        evictionDaysToKeep: 365,
+        invalidKey: 'should be ignored'
+      }
+
+      wrapper.vm.applyRestoredSettings(mockSettings)
+
+      expect(wrapper.vm.evictionEnabled).toBe(false)
+      expect(wrapper.vm.evictionDaysToKeep).toBe(365)
+
+      wrapper.unmount()
+    })
+
+    it('should reject invalid eviction settings during restore', () => {
+      const TestComponent = defineComponent({
+        setup() {
+          const settings = useSettings()
+          return settings
+        },
+        template: '<div></div>'
+      })
+
+      const wrapper = mount(TestComponent)
+
+      // Test with invalid eviction settings
+      const mockSettings = {
+        theme: 'dark',
+        targetWorkHours: 8,
+        reportingAppButtonText: 'Test',
+        reportingAppUrl: 'https://example.com',
+        evictionEnabled: 'invalid',
+        evictionDaysToKeep: 15 // Below minimum
+      }
+
+      wrapper.vm.applyRestoredSettings(mockSettings)
+
+      // Should keep defaults for invalid values
+      expect(wrapper.vm.evictionEnabled).toBe(true) // Default
+      expect(wrapper.vm.evictionDaysToKeep).toBe(180) // Default
+
+      wrapper.unmount()
+    })
+  })
 })

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -12,6 +12,10 @@ export function useSettings() {
   const reportingAppUrl = ref('')
   const tempReportingAppButtonText = ref('Tempo')
   const tempReportingAppUrl = ref('')
+  const evictionEnabled = ref(true)
+  const tempEvictionEnabled = ref(true)
+  const evictionDaysToKeep = ref(180)
+  const tempEvictionDaysToKeep = ref(180)
 
   // Media query for OS theme detection
   let mediaQueryList: MediaQueryList | null = null
@@ -191,6 +195,21 @@ export function useSettings() {
       }
     }
 
+    // Load eviction settings
+    const savedEvictionEnabled = localStorage.getItem('evictionEnabled')
+    if (savedEvictionEnabled !== null) {
+      const enabled = savedEvictionEnabled === 'true'
+      evictionEnabled.value = enabled
+    }
+
+    const savedEvictionDaysToKeep = localStorage.getItem('evictionDaysToKeep')
+    if (savedEvictionDaysToKeep) {
+      const days = parseInt(savedEvictionDaysToKeep, 10)
+      if (!isNaN(days) && days >= 30 && days <= 3650) {
+        evictionDaysToKeep.value = days
+      }
+    }
+
     applyTheme(currentTheme.value)
   }
 
@@ -220,6 +239,23 @@ export function useSettings() {
       reportingAppUrl.value = trimmedUrl
     }
 
+    // Validate and update eviction settings
+    evictionEnabled.value = tempEvictionEnabled.value
+    const coercedDays = Number(tempEvictionDaysToKeep.value)
+    if (Number.isFinite(coercedDays) && coercedDays >= 30 && coercedDays <= 3650) {
+      evictionDaysToKeep.value = coercedDays
+    } else {
+      // Keep old value or use safe default if current value is also invalid
+      if (
+        !Number.isFinite(evictionDaysToKeep.value) ||
+        evictionDaysToKeep.value < 30 ||
+        evictionDaysToKeep.value > 3650
+      ) {
+        evictionDaysToKeep.value = 180 // Safe default
+      }
+      // Note: tempEvictionDaysToKeep remains invalid, evictionDaysToKeep keeps valid value
+    }
+
     applyTheme(currentTheme.value)
 
     // Persist settings with error handling for storage quota/access issues
@@ -228,6 +264,8 @@ export function useSettings() {
       localStorage.setItem('targetWorkHours', targetWorkHours.value.toString())
       localStorage.setItem('reportingAppButtonText', reportingAppButtonText.value)
       localStorage.setItem('reportingAppUrl', reportingAppUrl.value)
+      localStorage.setItem('evictionEnabled', evictionEnabled.value.toString())
+      localStorage.setItem('evictionDaysToKeep', evictionDaysToKeep.value.toString())
     } catch (error) {
       console.warn('Failed to persist settings to localStorage:', error)
       // Continue execution - theme is already applied and in-memory state is updated
@@ -259,6 +297,21 @@ export function useSettings() {
   }
 
   /**
+   * Validate eviction enabled setting
+   */
+  const isValidEvictionEnabled = (value: unknown): value is boolean => {
+    return typeof value === 'boolean'
+  }
+
+  /**
+   * Validate eviction days to keep (minimum 30 days)
+   */
+  const isValidEvictionDaysToKeep = (value: unknown): value is number => {
+    const num = Number(value)
+    return Number.isFinite(num) && num >= 30 && num <= 3650 // 30 days to 10 years
+  }
+
+  /**
    * Sanitize and validate restored settings with strict key whitelisting
    */
   const sanitizeRestoredSettings = (input: unknown): Partial<SettingsSnapshot> => {
@@ -274,7 +327,9 @@ export function useSettings() {
       'theme',
       'targetWorkHours',
       'reportingAppButtonText',
-      'reportingAppUrl'
+      'reportingAppUrl',
+      'evictionEnabled',
+      'evictionDaysToKeep'
     ]
 
     for (const key of allowedKeys) {
@@ -304,6 +359,16 @@ export function useSettings() {
               sanitized.reportingAppUrl = urlStr
             }
             break
+          case 'evictionEnabled':
+            if (isValidEvictionEnabled(value)) {
+              sanitized.evictionEnabled = value
+            }
+            break
+          case 'evictionDaysToKeep':
+            if (isValidEvictionDaysToKeep(value)) {
+              sanitized.evictionDaysToKeep = value
+            }
+            break
         }
       }
     }
@@ -324,11 +389,15 @@ export function useSettings() {
       const hours = sanitizedSettings.targetWorkHours ?? targetWorkHours.value
       const buttonText = sanitizedSettings.reportingAppButtonText ?? reportingAppButtonText.value
       const url = sanitizedSettings.reportingAppUrl ?? reportingAppUrl.value
+      const evictionEnabledValue = sanitizedSettings.evictionEnabled ?? evictionEnabled.value
+      const evictionDaysValue = sanitizedSettings.evictionDaysToKeep ?? evictionDaysToKeep.value
 
       currentTheme.value = theme
       targetWorkHours.value = hours
       reportingAppButtonText.value = buttonText
       reportingAppUrl.value = url
+      evictionEnabled.value = evictionEnabledValue
+      evictionDaysToKeep.value = evictionDaysValue
 
       // Apply theme now
       applyTheme(currentTheme.value)
@@ -339,6 +408,8 @@ export function useSettings() {
         localStorage.setItem('targetWorkHours', targetWorkHours.value.toString())
         localStorage.setItem('reportingAppButtonText', reportingAppButtonText.value)
         localStorage.setItem('reportingAppUrl', reportingAppUrl.value)
+        localStorage.setItem('evictionEnabled', evictionEnabled.value.toString())
+        localStorage.setItem('evictionDaysToKeep', evictionDaysToKeep.value.toString())
       } catch (error) {
         console.warn('Failed to persist restored settings to localStorage:', error)
         // Continue execution - theme is already applied and in-memory state is updated
@@ -360,6 +431,8 @@ export function useSettings() {
     tempTargetWorkHours.value = targetWorkHours.value
     tempReportingAppButtonText.value = reportingAppButtonText.value
     tempReportingAppUrl.value = reportingAppUrl.value
+    tempEvictionEnabled.value = evictionEnabled.value
+    tempEvictionDaysToKeep.value = evictionDaysToKeep.value
   }
 
   // Load settings on mount and setup OS theme detection
@@ -402,7 +475,12 @@ export function useSettings() {
     reportingAppUrl,
     tempReportingAppButtonText,
     tempReportingAppUrl,
+    evictionEnabled,
+    tempEvictionEnabled,
+    evictionDaysToKeep,
+    tempEvictionDaysToKeep,
     isValidUrl,
+    isValidEvictionDaysToKeep,
     applyTheme,
     loadSettings,
     saveSettings,

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -198,15 +198,21 @@ export function useSettings() {
     // Load eviction settings
     const savedEvictionEnabled = localStorage.getItem('evictionEnabled')
     if (savedEvictionEnabled !== null) {
-      const enabled = savedEvictionEnabled === 'true'
-      evictionEnabled.value = enabled
+      // Only accept explicit 'true' or 'false' strings; reject corrupted values
+      if (savedEvictionEnabled === 'true') {
+        evictionEnabled.value = true
+      } else if (savedEvictionEnabled === 'false') {
+        evictionEnabled.value = false
+      }
+      // If corrupted (e.g., 'maybe'), keep current/default value
     }
 
     const savedEvictionDaysToKeep = localStorage.getItem('evictionDaysToKeep')
-    if (savedEvictionDaysToKeep) {
-      const days = parseInt(savedEvictionDaysToKeep, 10)
-      if (!isNaN(days) && days >= 30 && days <= 3650) {
-        evictionDaysToKeep.value = days
+    if (savedEvictionDaysToKeep !== null) {
+      // Use Number() for consistency with save validation
+      const days = Number(savedEvictionDaysToKeep)
+      if (Number.isFinite(days) && days >= 30 && days <= 3650) {
+        evictionDaysToKeep.value = Math.floor(days) // Normalize to integer
       }
     }
 

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -272,6 +272,12 @@ class DatabaseService {
     this.db.prepare('DELETE FROM task_records WHERE id = ?').run(id)
   }
 
+  deleteOldTaskRecords(cutoffDate: string): number {
+    const deleteStmt = this.db.prepare('DELETE FROM task_records WHERE date < ?')
+    const result = deleteStmt.run(cutoffDate)
+    return result.changes
+  }
+
   close() {
     this.db.close()
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -194,6 +194,15 @@ ipcMain.handle('db:delete-task-record', async (_, id: number) => {
   }
 })
 
+ipcMain.handle('db:delete-old-task-records', async (_, cutoffDate: string) => {
+  try {
+    return dbService.deleteOldTaskRecords(cutoffDate)
+  } catch (error) {
+    console.error('Failed to delete old task records:', error)
+    throw new Error(`Failed to delete old task records: ${error instanceof Error ? error.message : 'Unknown error'}`)
+  }
+})
+
 // Application info handler
 ipcMain.handle('app:get-version', async () => {
   return app.getVersion()

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,6 +3,7 @@ import { promises as fsp } from 'fs'
 import { join } from 'path'
 import { dbService } from './database'
 import { normalizeCategories, normalizeTaskRecords } from './backupUtils'
+import { validateCutoffDate } from './validation'
 import { TASK_TYPE_END, TASK_TYPES } from '../shared/types'
 import type { TaskRecord, TaskRecordInsert, TaskRecordUpdate, DatabaseError, SettingsSnapshot } from '../shared/types'
 
@@ -195,8 +196,17 @@ ipcMain.handle('db:delete-task-record', async (_, id: number) => {
 })
 
 ipcMain.handle('db:delete-old-task-records', async (_, cutoffDate: string) => {
+  // Validate cutoffDate early - throw validation error immediately if invalid
   try {
-    return dbService.deleteOldTaskRecords(cutoffDate)
+    validateCutoffDate(cutoffDate)
+  } catch (validationError) {
+    // Validation failed - throw error early without attempting database operation
+    throw validationError
+  }
+
+  // Validation passed - proceed with database operation
+  try {
+    return await dbService.deleteOldTaskRecords(cutoffDate)
   } catch (error) {
     console.error('Failed to delete old task records:', error)
     throw new Error(`Failed to delete old task records: ${error instanceof Error ? error.message : 'Unknown error'}`)

--- a/src/main/validation.test.ts
+++ b/src/main/validation.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest'
+import { validateCutoffDate } from './validation'
+
+describe('validateCutoffDate', () => {
+  describe('Input validation', () => {
+    it('should reject non-string inputs', () => {
+      const invalidInputs = [null, undefined, 123, {}, [], true]
+
+      for (const input of invalidInputs) {
+        expect(() => validateCutoffDate(input as any)).toThrow('Invalid cutoffDate: must be a non-empty string')
+      }
+    })
+
+    it('should reject empty or whitespace-only strings', () => {
+      const invalidStrings = ['', '   ', '\t\n  ']
+
+      for (const input of invalidStrings) {
+        expect(() => validateCutoffDate(input)).toThrow('Invalid cutoffDate: must be a non-empty string')
+      }
+    })
+
+    it('should reject invalid date strings', () => {
+      const invalidDates = ['not-a-date', 'invalid-date-format']
+
+      for (const input of invalidDates) {
+        expect(() => validateCutoffDate(input)).toThrow('Invalid cutoffDate: must match YYYY-MM-DD format')
+      }
+    })
+
+    it('should reject future dates', () => {
+      const tomorrow = new Date()
+      tomorrow.setDate(tomorrow.getDate() + 1)
+      const tomorrowISO = tomorrow.toISOString().split('T')[0]
+
+      const nextWeek = new Date()
+      nextWeek.setDate(nextWeek.getDate() + 7)
+      const nextWeekISO = nextWeek.toISOString().split('T')[0]
+
+      expect(() => validateCutoffDate(tomorrowISO)).toThrow('Invalid cutoffDate: cannot be in the future')
+
+      expect(() => validateCutoffDate(nextWeekISO)).toThrow('Invalid cutoffDate: cannot be in the future')
+    })
+
+    it('should reject dates with unreasonable years', () => {
+      const veryOldDate = '1969-01-01'
+      const veryFutureDate = '2050-01-01' // Far enough in future to trigger year check
+
+      expect(() => validateCutoffDate(veryOldDate)).toThrow(
+        'Invalid cutoffDate: year must be reasonable (1970 to current year)'
+      )
+
+      expect(() => validateCutoffDate(veryFutureDate)).toThrow(
+        'Invalid cutoffDate: year must be reasonable (1970 to current year)'
+      )
+    })
+  })
+
+  describe('Valid inputs', () => {
+    it('should accept valid past dates', () => {
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+      const yesterdayISO = yesterday.toISOString().split('T')[0]
+
+      const result = validateCutoffDate(yesterdayISO)
+
+      expect(result).toBe(yesterdayISO)
+    })
+
+    it('should accept today as cutoff date', () => {
+      const today = new Date().toISOString().split('T')[0]
+
+      const result = validateCutoffDate(today)
+
+      expect(result).toBe(today)
+    })
+
+    it('should accept dates from the valid year range', () => {
+      const validDates = ['1970-01-01', '2000-06-15', '2020-12-25']
+
+      for (const date of validDates) {
+        const result = validateCutoffDate(date)
+        expect(result).toBe(date)
+      }
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should handle leap year dates correctly', () => {
+      // Test a leap year date (2020 was a leap year)
+      const leapYearDate = '2020-02-29'
+
+      const result = validateCutoffDate(leapYearDate)
+
+      expect(result).toBe(leapYearDate)
+    })
+
+    it('should handle different ISO date formats correctly', () => {
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+
+      // Test YYYY-MM-DD format
+      const dateOnly = yesterday.toISOString().split('T')[0]
+
+      const result = validateCutoffDate(dateOnly)
+
+      expect(result).toBe(dateOnly)
+    })
+  })
+})

--- a/src/main/validation.test.ts
+++ b/src/main/validation.test.ts
@@ -42,6 +42,25 @@ describe('validateCutoffDate', () => {
       expect(() => validateCutoffDate(nextWeekISO)).toThrow('Invalid cutoffDate: cannot be in the future')
     })
 
+    it('should reject dates that are less than 30 days before today', () => {
+      const today = new Date()
+
+      // Test yesterday (too recent)
+      const yesterday = new Date(today.getTime() - 1 * 24 * 60 * 60 * 1000)
+      const yesterdayISO = yesterday.toISOString().split('T')[0]
+
+      // Test 29 days ago (still too recent)
+      const twentyNineDaysAgo = new Date(today.getTime() - 29 * 24 * 60 * 60 * 1000)
+      const twentyNineDaysAgoISO = twentyNineDaysAgo.toISOString().split('T')[0]
+
+      expect(() => validateCutoffDate(yesterdayISO)).toThrow(
+        'Invalid cutoffDate: must be at least 30 days before today'
+      )
+      expect(() => validateCutoffDate(twentyNineDaysAgoISO)).toThrow(
+        'Invalid cutoffDate: must be at least 30 days before today'
+      )
+    })
+
     it('should reject dates with unreasonable years', () => {
       const veryOldDate = '1969-01-01'
       const veryFutureDate = '2050-01-01' // Far enough in future to trigger year check
@@ -57,28 +76,36 @@ describe('validateCutoffDate', () => {
   })
 
   describe('Valid inputs', () => {
-    it('should accept valid past dates', () => {
-      const yesterday = new Date()
-      yesterday.setDate(yesterday.getDate() - 1)
-      const yesterdayISO = yesterday.toISOString().split('T')[0]
+    it('should accept dates that are exactly 30 days before today', () => {
+      const today = new Date()
+      const thirtyDaysAgo = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000)
+      const thirtyDaysAgoISO = thirtyDaysAgo.toISOString().split('T')[0]
 
-      const result = validateCutoffDate(yesterdayISO)
+      const result = validateCutoffDate(thirtyDaysAgoISO)
 
-      expect(result).toBe(yesterdayISO)
+      expect(result).toBe(thirtyDaysAgoISO)
     })
 
-    it('should accept today as cutoff date', () => {
-      const today = new Date().toISOString().split('T')[0]
+    it('should accept dates that are more than 30 days before today', () => {
+      const today = new Date()
 
-      const result = validateCutoffDate(today)
+      // Test 31 days ago
+      const thirtyOneDaysAgo = new Date(today.getTime() - 31 * 24 * 60 * 60 * 1000)
+      const thirtyOneDaysAgoISO = thirtyOneDaysAgo.toISOString().split('T')[0]
 
-      expect(result).toBe(today)
+      // Test 60 days ago
+      const sixtyDaysAgo = new Date(today.getTime() - 60 * 24 * 60 * 60 * 1000)
+      const sixtyDaysAgoISO = sixtyDaysAgo.toISOString().split('T')[0]
+
+      expect(validateCutoffDate(thirtyOneDaysAgoISO)).toBe(thirtyOneDaysAgoISO)
+      expect(validateCutoffDate(sixtyDaysAgoISO)).toBe(sixtyDaysAgoISO)
     })
 
-    it('should accept dates from the valid year range', () => {
-      const validDates = ['1970-01-01', '2000-06-15', '2020-12-25']
+    it('should accept old dates from the valid year range', () => {
+      // Use dates that are definitely more than 30 days old
+      const validOldDates = ['1970-01-01', '2000-06-15', '2020-12-25']
 
-      for (const date of validDates) {
+      for (const date of validOldDates) {
         const result = validateCutoffDate(date)
         expect(result).toBe(date)
       }
@@ -87,7 +114,7 @@ describe('validateCutoffDate', () => {
 
   describe('Edge cases', () => {
     it('should handle leap year dates correctly', () => {
-      // Test a leap year date (2020 was a leap year)
+      // Test a leap year date (2020 was a leap year) - this is definitely more than 30 days old
       const leapYearDate = '2020-02-29'
 
       const result = validateCutoffDate(leapYearDate)
@@ -96,11 +123,12 @@ describe('validateCutoffDate', () => {
     })
 
     it('should handle different ISO date formats correctly', () => {
-      const yesterday = new Date()
-      yesterday.setDate(yesterday.getDate() - 1)
+      // Use a date that's definitely more than 30 days old
+      const oldDate = new Date()
+      oldDate.setDate(oldDate.getDate() - 60) // 60 days ago
 
       // Test YYYY-MM-DD format
-      const dateOnly = yesterday.toISOString().split('T')[0]
+      const dateOnly = oldDate.toISOString().split('T')[0]
 
       const result = validateCutoffDate(dateOnly)
 

--- a/src/main/validation.ts
+++ b/src/main/validation.ts
@@ -1,0 +1,37 @@
+export function validateCutoffDate(cutoffDate: unknown): string {
+  // Defense-in-depth: validate cutoffDate before calling database method
+  if (typeof cutoffDate !== 'string' || cutoffDate.trim() === '') {
+    throw new Error('Invalid cutoffDate: must be a non-empty string')
+  }
+
+  // Strict regex validation for YYYY-MM-DD format
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/
+  if (!dateRegex.test(cutoffDate)) {
+    throw new Error('Invalid cutoffDate: must match YYYY-MM-DD format')
+  }
+
+  // Parse date and validate it's a real date
+  const parsedDate = new Date(cutoffDate)
+  if (isNaN(parsedDate.getTime())) {
+    throw new Error('Invalid cutoffDate: must be a valid date')
+  }
+
+  // Validate year range (reject very old or future years)
+  const year = parsedDate.getFullYear()
+  const currentYear = new Date().getFullYear()
+  if (year < 1970 || year > currentYear) {
+    throw new Error('Invalid cutoffDate: year must be reasonable (1970 to current year)')
+  }
+
+  // Compare with today using UTC/zeroed time to prevent future dates
+  const today = new Date()
+  today.setHours(0, 0, 0, 0) // Zero out time for accurate date comparison
+  parsedDate.setHours(0, 0, 0, 0) // Zero out time for accurate date comparison
+
+  if (parsedDate > today) {
+    throw new Error('Invalid cutoffDate: cannot be in the future')
+  }
+
+  // Return the validated string
+  return cutoffDate
+}

--- a/src/main/validation.ts
+++ b/src/main/validation.ts
@@ -28,8 +28,15 @@ export function validateCutoffDate(cutoffDate: unknown): string {
   today.setHours(0, 0, 0, 0) // Zero out time for accurate date comparison
   parsedDate.setHours(0, 0, 0, 0) // Zero out time for accurate date comparison
 
+  // Ensure cutoff date is at least 30 days before today
+  const thirtyDaysAgo = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000)
+
   if (parsedDate > today) {
     throw new Error('Invalid cutoffDate: cannot be in the future')
+  }
+
+  if (parsedDate > thirtyDaysAgo) {
+    throw new Error('Invalid cutoffDate: must be at least 30 days before today')
   }
 
   // Return the validated string

--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -999,7 +999,13 @@ describe('App Component', () => {
       const vm = wrapper.vm as any
       await vm.backupApp()
       expect(backupSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ theme: 'light', targetWorkHours: 8, reportingAppButtonText: 'Tempo' })
+        expect.objectContaining({
+          theme: 'light',
+          targetWorkHours: 8,
+          reportingAppButtonText: 'Tempo',
+          evictionEnabled: true,
+          evictionDaysToKeep: 180
+        })
       )
       expect(wrapper.find('.toast').exists()).toBe(true)
       expect(wrapper.text()).toContain('Backup saved successfully')
@@ -2959,6 +2965,7 @@ describe('App Component', () => {
       vi.useFakeTimers()
       await vi.advanceTimersByTimeAsync(1100)
       vi.useRealTimers()
+      await nextTick() // Ensure component is fully initialized
       const vm = wrapper.vm as any
 
       await vm.backupApp()

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -78,7 +78,10 @@
       :temp-target-work-hours="tempTargetWorkHours"
       :temp-reporting-app-button-text="tempReportingAppButtonText"
       :temp-reporting-app-url="tempReportingAppUrl"
+      :temp-eviction-enabled="tempEvictionEnabled"
+      :temp-eviction-days-to-keep="tempEvictionDaysToKeep"
       :is-valid-url="isValidUrl"
+      :is-valid-eviction-days-to-keep="isValidEvictionDaysToKeep"
       :categories="categories"
       :is-loading-categories="isLoadingCategories"
       :is-adding-category="isAddingCategory"
@@ -94,6 +97,8 @@
       @update-temp-target-work-hours="hours => (tempTargetWorkHours = hours)"
       @update-temp-reporting-app-button-text="text => (tempReportingAppButtonText = text)"
       @update-temp-reporting-app-url="url => (tempReportingAppUrl = url)"
+      @update-temp-eviction-enabled="enabled => (tempEvictionEnabled = enabled)"
+      @update-temp-eviction-days-to-keep="days => (tempEvictionDaysToKeep = days)"
       @start-edit-category="startEditCategory"
       @update-editing-category-name="name => (editingCategoryName = name)"
       @save-edit-category="saveEditCategory"
@@ -249,7 +254,12 @@ const {
   reportingAppUrl,
   tempReportingAppButtonText,
   tempReportingAppUrl,
+  evictionEnabled,
+  tempEvictionEnabled,
+  evictionDaysToKeep,
+  tempEvictionDaysToKeep,
   isValidUrl,
+  isValidEvictionDaysToKeep,
   applyTheme,
   saveSettings: saveSettingsComposable,
   initializeTempSettings,
@@ -450,7 +460,9 @@ const backupApp = async () => {
     theme: currentTheme.value,
     targetWorkHours: targetWorkHours.value,
     reportingAppButtonText: reportingAppButtonText.value,
-    reportingAppUrl: reportingAppUrl.value
+    reportingAppUrl: reportingAppUrl.value,
+    evictionEnabled: evictionEnabled?.value ?? true,
+    evictionDaysToKeep: evictionDaysToKeep?.value ?? 180
   }
   try {
     const res = await window.electronAPI.backupApp(settings)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -56,6 +56,8 @@ export interface SettingsSnapshot {
   targetWorkHours: number
   reportingAppButtonText: string
   reportingAppUrl: string
+  evictionEnabled: boolean
+  evictionDaysToKeep: number
 }
 
 // IPC result types for backup/restore flows
@@ -91,6 +93,7 @@ export interface ElectronAPI {
   getTaskRecordsByDate: (date: string) => Promise<TaskRecordWithId[]>
   updateTaskRecord: (id: number, record: TaskRecordUpdate) => Promise<void>
   deleteTaskRecord: (id: number) => Promise<void>
+  deleteOldTaskRecords: (cutoffDate: string) => Promise<number>
   debugAll?: () => Promise<any>
 }
 


### PR DESCRIPTION
…ality

- Added new settings for enabling/disabling eviction and configuring retention days.
- Integrated eviction logic during "End" task creation to remove old records automatically.
- Updated UI to include eviction settings in the Setup Modal.
- Updated database and IPC handlers to support old task entries deletion.
- Extended tests for new eviction settings and logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Old Entries Cleanup” setting with enable toggle and validated retention input (30–3650 days); automatic cleanup can run after ending a task and is included in backups/restores.
  - App can request removal of old task records via a new backend action (with input validation).

- **Tests**
  - Expanded tests covering defaults, validation, persistence, backup/restore integration, and corrupted-storage scenarios.

- **Style**
  - Helper text and visual states for disabled/invalid cleanup controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->