### PR TITLE
feat(http-server): add HTTP server support for creating task entries via GET requests

### DIFF
--- a/src/components/DateNavigation.test.ts
+++ b/src/components/DateNavigation.test.ts
@@ -234,5 +234,101 @@ describe('DateNavigation', () => {
       expect(emitted).toHaveProperty('openSetup')
       expect(emitted.openSetup?.length).toBe(1)
     })
+
+    it('renders normal settings button when no HTTP server error', () => {
+      const wrapper = mount(DateNavigation, { props: minimalProps })
+
+      const settingsBtn = wrapper.get('button[aria-label="Open settings"]')
+      expect(settingsBtn.classes()).not.toContain('has-error')
+      expect(settingsBtn.attributes('title')).toBe('Open Settings')
+      expect(settingsBtn.attributes('aria-label')).toBe('Open settings')
+
+      const errorIndicator = wrapper.find('.error-indicator')
+      expect(errorIndicator.exists()).toBe(false)
+    })
+
+    it('renders error state when HTTP server error is provided', () => {
+      const errorMessage = 'Failed to start server: EADDRINUSE'
+      const wrapper = mount(DateNavigation, {
+        props: {
+          ...minimalProps,
+          httpServerError: errorMessage
+        }
+      })
+
+      const settingsBtn = wrapper.get(
+        'button[aria-label="Open settings - HTTP Server Error: Failed to start server: EADDRINUSE"]'
+      )
+      expect(settingsBtn.classes()).toContain('has-error')
+      expect(settingsBtn.attributes('title')).toBe('Settings (HTTP Server Error: Failed to start server: EADDRINUSE)')
+      expect(settingsBtn.attributes('aria-label')).toBe(
+        'Open settings - HTTP Server Error: Failed to start server: EADDRINUSE'
+      )
+    })
+
+    it('renders error indicator when HTTP server error is provided', () => {
+      const wrapper = mount(DateNavigation, {
+        props: {
+          ...minimalProps,
+          httpServerError: 'Port in use'
+        }
+      })
+
+      const errorIndicator = wrapper.get('.error-indicator')
+      expect(errorIndicator.exists()).toBe(true)
+      expect(errorIndicator.attributes('aria-hidden')).toBe('true')
+      expect(errorIndicator.text()).toBe('🔴')
+    })
+
+    it('handles empty HTTP server error message', () => {
+      const wrapper = mount(DateNavigation, {
+        props: {
+          ...minimalProps,
+          httpServerError: ''
+        }
+      })
+
+      const settingsBtn = wrapper.get('.setup-btn')
+      expect(settingsBtn.classes()).not.toContain('has-error')
+      expect(settingsBtn.attributes('title')).toBe('Open Settings')
+
+      const errorIndicator = wrapper.find('.error-indicator')
+      expect(errorIndicator.exists()).toBe(false)
+    })
+
+    it('handles long HTTP server error messages', () => {
+      const longError =
+        'Very long error message that might exceed typical display limits and needs to be handled gracefully in the UI'
+      const wrapper = mount(DateNavigation, {
+        props: {
+          ...minimalProps,
+          httpServerError: longError
+        }
+      })
+
+      const settingsBtn = wrapper.get('.setup-btn')
+      expect(settingsBtn.classes()).toContain('has-error')
+      expect(settingsBtn.attributes('title')).toBe(`Settings (HTTP Server Error: ${longError})`)
+      expect(settingsBtn.attributes('aria-label')).toBe(`Open settings - HTTP Server Error: ${longError}`)
+
+      const errorIndicator = wrapper.get('.error-indicator')
+      expect(errorIndicator.exists()).toBe(true)
+    })
+
+    it('maintains button functionality when in error state', async () => {
+      const wrapper = mount(DateNavigation, {
+        props: {
+          ...minimalProps,
+          httpServerError: 'Server error'
+        }
+      })
+
+      const settingsBtn = wrapper.get('.setup-btn.has-error')
+      await settingsBtn.trigger('click')
+
+      const emitted = wrapper.emitted()
+      expect(emitted).toHaveProperty('openSetup')
+      expect(emitted.openSetup?.length).toBe(1)
+    })
   })
 })

--- a/src/components/DateNavigation.vue
+++ b/src/components/DateNavigation.vue
@@ -49,11 +49,13 @@
     <button
       type="button"
       class="setup-btn"
+      :class="{ 'has-error': httpServerError }"
       @click="$emit('openSetup')"
-      title="Open Settings"
-      aria-label="Open settings"
+      :title="httpServerError ? `Settings (HTTP Server Error: ${httpServerError})` : 'Open Settings'"
+      :aria-label="httpServerError ? `Open settings - HTTP Server Error: ${httpServerError}` : 'Open settings'"
     >
       <span class="setup-icon" aria-hidden="true">⚙️</span>
+      <span v-if="httpServerError" class="error-indicator" aria-hidden="true">🔴</span>
       Settings
     </button>
   </nav>
@@ -68,6 +70,7 @@ defineProps<{
   dateInputValue: string
   reportingAppButtonText: string
   reportingAppUrl: string
+  httpServerError?: string
 }>()
 
 // Emits
@@ -219,6 +222,7 @@ const dateInputId = useId()
   color: var(--text-primary);
   font-weight: 600;
   transition: all 0.2s ease;
+  position: relative;
 }
 
 .setup-btn:hover {
@@ -230,6 +234,31 @@ const dateInputId = useId()
 
 .setup-icon {
   font-size: 16px;
+}
+
+.setup-btn.has-error {
+  border-color: #e74c3c;
+  background: rgba(231, 76, 60, 0.1);
+}
+
+.setup-btn.has-error:hover {
+  background: #e74c3c;
+  border-color: #e74c3c;
+}
+
+.error-indicator {
+  font-size: 12px;
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  background: white;
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .app-icon {

--- a/src/components/SetupModal.vue
+++ b/src/components/SetupModal.vue
@@ -205,6 +205,49 @@
           </div>
         </div>
 
+        <!-- HTTP Server -->
+        <div class="setting-group">
+          <h4>HTTP Server</h4>
+          <div class="http-server-settings">
+            <div class="http-server-enabled-setting">
+              <label class="checkbox-container">
+                <input
+                  type="checkbox"
+                  :checked="tempHttpServerEnabled"
+                  @change="$emit('updateTempHttpServerEnabled', ($event.target as HTMLInputElement).checked)"
+                  class="http-server-checkbox"
+                />
+                <span class="checkmark"></span>
+                Enable HTTP server
+              </label>
+            </div>
+            <div class="http-server-port-setting" :class="{ disabled: !tempHttpServerEnabled }">
+              <label for="http-server-port">Port number:</label>
+              <input
+                type="number"
+                id="http-server-port"
+                :value="tempHttpServerPort"
+                @input="onHttpServerPortInput($event)"
+                @blur="onHttpServerPortBlur($event)"
+                min="1024"
+                max="65535"
+                step="1"
+                class="http-server-port-input"
+                :class="{ 'invalid-input': !isValidHttpPort(tempHttpServerPort) }"
+                :disabled="!tempHttpServerEnabled"
+              />
+            </div>
+            <div class="http-server-help">
+              <p class="setting-description">
+                When enabled, allows creating task entries via HTTP GET requests to localhost. Use:
+                <code
+                  >http://localhost:{{ tempHttpServerPort }}/create-task?task=TaskName&amp;category=CategoryName</code
+                >
+              </p>
+            </div>
+          </div>
+        </div>
+
         <!-- Backup & Restore -->
         <div class="setting-group">
           <h4>Backup & Restore</h4>
@@ -318,6 +361,18 @@ const props = defineProps({
   isValidEvictionDaysToKeep: {
     type: Function as PropType<(value: unknown) => boolean>,
     required: true
+  },
+  tempHttpServerEnabled: {
+    type: Boolean,
+    required: true
+  },
+  tempHttpServerPort: {
+    type: Number,
+    required: true
+  },
+  isValidHttpPort: {
+    type: Function as PropType<(value: unknown) => boolean>,
+    required: true
   }
 })
 
@@ -341,6 +396,8 @@ const emit = defineEmits<{
   updateTempReportingAppUrl: [url: string]
   updateTempEvictionEnabled: [enabled: boolean]
   updateTempEvictionDaysToKeep: [days: number]
+  updateTempHttpServerEnabled: [enabled: boolean]
+  updateTempHttpServerPort: [port: number]
   backup: []
   restoreBackup: []
 }>()
@@ -366,6 +423,19 @@ function onEvictionDaysInput(e: Event) {
   const raw = parseInt((e.target as HTMLInputElement).value, 10)
   const clamped = Number.isFinite(raw) ? Math.min(3650, Math.max(30, raw)) : 30
   emit('updateTempEvictionDaysToKeep', clamped)
+}
+
+function onHttpServerPortInput(e: Event) {
+  const raw = parseInt((e.target as HTMLInputElement).value, 10)
+  // Allow free typing - only emit the raw value without clamping
+  emit('updateTempHttpServerPort', Number.isFinite(raw) ? raw : 14474)
+}
+
+function onHttpServerPortBlur(e: Event) {
+  const raw = parseInt((e.target as HTMLInputElement).value, 10)
+  // Clamp to valid range when user finishes typing
+  const clamped = Number.isFinite(raw) ? Math.min(65535, Math.max(1024, raw)) : 14474
+  emit('updateTempHttpServerPort', clamped)
 }
 
 function handleEscapeCancel() {
@@ -963,5 +1033,82 @@ onUnmounted(() => {
   background: var(--bg-secondary);
   border-radius: 6px;
   border-left: 3px solid var(--primary);
+}
+
+/* HTTP Server */
+.http-server-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.http-server-enabled-setting {
+  display: flex;
+  align-items: center;
+}
+
+.http-server-port-setting {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  transition: opacity 0.2s ease;
+}
+
+.http-server-port-setting.disabled {
+  opacity: 0.5;
+}
+
+.http-server-port-setting label {
+  color: var(--text-primary);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.http-server-port-input {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 8px 12px;
+  color: var(--text-primary);
+  width: 100px;
+  text-align: center;
+  transition: all 0.2s ease;
+}
+
+.http-server-port-input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(87, 189, 175, 0.1);
+}
+
+.http-server-port-input:disabled {
+  cursor: not-allowed;
+  background: var(--border-color);
+  color: var(--text-muted);
+}
+
+.http-server-port-input.invalid-input {
+  border-color: #e74c3c;
+  box-shadow: 0 0 0 2px rgba(231, 76, 60, 0.1);
+}
+
+.http-server-help {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 12px;
+  background: var(--bg-secondary);
+  border-radius: 6px;
+  border-left: 3px solid var(--primary);
+}
+
+.http-server-help code {
+  background: var(--bg-primary);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: 'Courier New', monospace;
+  font-size: 11px;
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
 }
 </style>

--- a/src/composables/useAutoRefresh.test.ts
+++ b/src/composables/useAutoRefresh.test.ts
@@ -1,7 +1,40 @@
 // Fixed duplicate imports
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { ref, effectScope } from 'vue'
+import { ref, effectScope, defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
 import { useAutoRefresh } from './useAutoRefresh'
+
+// Extract the formatLocalDateString function for testing
+// This mirrors the implementation in useAutoRefresh.ts
+function formatLocalDateString(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+describe('formatLocalDateString helper', () => {
+  it('should format dates correctly', () => {
+    expect(formatLocalDateString(new Date('2024-01-01T10:30:00'))).toBe('2024-01-01')
+    expect(formatLocalDateString(new Date('2024-12-31T23:59:59'))).toBe('2024-12-31')
+    expect(formatLocalDateString(new Date('2024-02-29T00:00:00'))).toBe('2024-02-29') // Leap year
+  })
+
+  it('should handle single digit months and days with zero padding', () => {
+    expect(formatLocalDateString(new Date('2024-01-05T12:00:00'))).toBe('2024-01-05')
+    expect(formatLocalDateString(new Date('2024-09-01T12:00:00'))).toBe('2024-09-01')
+    expect(formatLocalDateString(new Date('2024-10-10T12:00:00'))).toBe('2024-10-10')
+  })
+
+  it('should handle different timezones consistently by using local date components', () => {
+    // Create dates in different ways to test consistency
+    const date1 = new Date(2024, 0, 15) // Local timezone January 15, 2024
+    const date2 = new Date('2024-01-15T12:00:00') // Parsed as local time in most environments
+
+    expect(formatLocalDateString(date1)).toBe('2024-01-15')
+    expect(formatLocalDateString(date2)).toBe('2024-01-15')
+  })
+})
 
 describe('useAutoRefresh', () => {
   let mockCallback: ReturnType<typeof vi.fn>
@@ -13,12 +46,33 @@ describe('useAutoRefresh', () => {
     mockCallback = vi.fn()
     selectedDate = ref(new Date())
     scope = effectScope()
+
+    // Mock window object with DOM timer methods for all tests
+    ;(global as any).window = {
+      setInterval: vi.fn((fn: Function, ms: number) => {
+        return setInterval(fn, ms) as any
+      }),
+      clearInterval: vi.fn((id: any) => {
+        clearInterval(id)
+      })
+    }
+
+    // Suppress Vue lifecycle warnings in test environment
+    const originalWarn = console.warn
+    vi.spyOn(console, 'warn').mockImplementation(message => {
+      if ((typeof message === 'string' && message.includes('onMounted')) || message.includes('onUnmounted')) {
+        return // Suppress Vue lifecycle warnings
+      }
+      originalWarn(message)
+    })
   })
 
   afterEach(() => {
     vi.clearAllTimers()
     vi.useRealTimers()
     scope.stop()
+    delete (global as any).window
+    vi.restoreAllMocks()
   })
 
   it('should call callback every 15s when date is today', () => {
@@ -76,6 +130,387 @@ describe('useAutoRefresh', () => {
       restartAutoRefresh()
       vi.advanceTimersByTime(15000)
       expect(mockCallback).toHaveBeenCalledTimes(2)
+
+      stopAutoRefresh()
+    })
+  })
+
+  describe('HTTP Server Integration', () => {
+    let mockElectronAPI: any
+
+    beforeEach(() => {
+      // Add electronAPI to existing window mock
+      mockElectronAPI = {
+        onHttpServerTaskCreated: vi.fn(),
+        removeHttpServerTaskCreatedListener: vi.fn()
+      }
+      ;(global as any).window.electronAPI = mockElectronAPI
+    })
+
+    afterEach(() => {
+      // Clean up electronAPI but keep window object
+      delete (global as any).window.electronAPI
+    })
+
+    it('should register HTTP server task created listener on mount', () => {
+      // Since onMounted doesn't fire in effectScope, we'll test the actual handler logic by simulation
+      expect(() => {
+        scope.run(() => useAutoRefresh(selectedDate, mockCallback))
+      }).not.toThrow()
+
+      // Test would normally check onMounted registration, but that doesn't work in effectScope
+      // The important thing is that the composable initializes without error
+    })
+
+    it('should call refresh callback when HTTP task is created for current date', () => {
+      scope.run(() => useAutoRefresh(selectedDate, mockCallback))
+
+      // Simulate the HTTP task created handler directly since onMounted doesn't fire in tests
+      const handleHttpTaskCreated = (data: any) => {
+        const currentDateString = selectedDate.value.toISOString().split('T')[0]
+
+        // Only refresh if the task was created for the currently viewed date
+        if (data.date === currentDateString) {
+          try {
+            mockCallback()
+          } catch (error) {
+            console.error('[useAutoRefresh] Error during HTTP task creation refresh:', error)
+          }
+        }
+      }
+
+      // Set today's date
+      const today = new Date()
+      selectedDate.value = today
+      const todayString = today.toISOString().split('T')[0]
+
+      // Simulate HTTP task creation for today
+      handleHttpTaskCreated({ date: todayString })
+
+      expect(mockCallback).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not call refresh callback when HTTP task is created for different date', () => {
+      scope.run(() => useAutoRefresh(selectedDate, mockCallback))
+
+      // Simulate the HTTP task created handler directly
+      const handleHttpTaskCreated = (data: any) => {
+        const currentDateString = selectedDate.value.toISOString().split('T')[0]
+
+        if (data.date === currentDateString) {
+          try {
+            mockCallback()
+          } catch (error) {
+            console.error('[useAutoRefresh] Error during HTTP task creation refresh:', error)
+          }
+        }
+      }
+
+      // Set today's date
+      const today = new Date()
+      selectedDate.value = today
+
+      // Simulate HTTP task creation for different date
+      handleHttpTaskCreated({ date: '2023-01-01' })
+
+      expect(mockCallback).not.toHaveBeenCalled()
+    })
+
+    it('should handle HTTP task creation refresh errors gracefully', () => {
+      const errorCallback = vi.fn(() => {
+        throw new Error('Refresh failed')
+      })
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      scope.run(() => useAutoRefresh(selectedDate, errorCallback))
+
+      // Simulate the HTTP task created handler directly
+      const handleHttpTaskCreated = (data: any) => {
+        const currentDateString = selectedDate.value.toISOString().split('T')[0]
+
+        if (data.date === currentDateString) {
+          try {
+            errorCallback()
+          } catch (error) {
+            console.error('[useAutoRefresh] Error during HTTP task creation refresh:', error)
+          }
+        }
+      }
+
+      // Set today's date
+      const today = new Date()
+      selectedDate.value = today
+      const todayString = today.toISOString().split('T')[0]
+
+      // Simulate HTTP task creation with error
+      handleHttpTaskCreated({ date: todayString })
+
+      expect(errorCallback).toHaveBeenCalledTimes(1)
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[useAutoRefresh] Error during HTTP task creation refresh:',
+        expect.any(Error)
+      )
+
+      consoleSpy.mockRestore()
+    })
+
+    it('should clean up HTTP server event listener on unmount', () => {
+      // Since onMounted/onUnmounted don't fire in effectScope, just test that cleanup doesn't throw
+      expect(() => {
+        const composable = scope.run(() => useAutoRefresh(selectedDate, mockCallback))!
+        scope.stop()
+      }).not.toThrow()
+    })
+
+    it('should handle missing electronAPI gracefully', () => {
+      // Remove electronAPI from window
+      delete (global as any).window.electronAPI
+
+      // Should not throw error
+      expect(() => {
+        scope.run(() => useAutoRefresh(selectedDate, mockCallback))
+      }).not.toThrow()
+    })
+
+    it('should handle missing HTTP server methods gracefully', () => {
+      // Set up electronAPI without HTTP server methods
+      ;(global as any).window.electronAPI = {}
+
+      // Should not throw error
+      expect(() => {
+        scope.run(() => useAutoRefresh(selectedDate, mockCallback))
+      }).not.toThrow()
+    })
+  })
+
+  describe('Auto-refresh Error Handling', () => {
+    it('should handle auto-refresh callback errors gracefully', () => {
+      const errorCallback = vi.fn(() => {
+        throw new Error('Refresh failed')
+      })
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { startAutoRefresh } = scope.run(() => useAutoRefresh(selectedDate, errorCallback))!
+      startAutoRefresh()
+
+      // Advance timer to trigger callback
+      vi.advanceTimersByTime(15000)
+
+      expect(errorCallback).toHaveBeenCalledTimes(1)
+      expect(consoleSpy).toHaveBeenCalledWith('[useAutoRefresh] Error during auto-refresh callback:', expect.any(Error))
+
+      // Should continue running the interval
+      vi.advanceTimersByTime(15000)
+      expect(errorCallback).toHaveBeenCalledTimes(2)
+
+      consoleSpy.mockRestore()
+    })
+
+    it('should stop auto-refresh when date is no longer today', () => {
+      // Set initial date to today
+      const today = new Date()
+      selectedDate.value = today
+
+      const { startAutoRefresh } = scope.run(() => useAutoRefresh(selectedDate, mockCallback))!
+      startAutoRefresh()
+
+      // Advance timer once - should work
+      vi.advanceTimersByTime(15000)
+      expect(mockCallback).toHaveBeenCalledTimes(1)
+
+      // Change date to yesterday
+      const yesterday = new Date(today)
+      yesterday.setDate(yesterday.getDate() - 1)
+      selectedDate.value = yesterday
+
+      // Advance timer again - should stop auto-refresh
+      vi.advanceTimersByTime(15000)
+      // Callback should not be called again since auto-refresh should have stopped
+      expect(mockCallback).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Vue Component Integration', () => {
+    let mockElectronAPI: any
+
+    beforeEach(() => {
+      // Set up proper window and electronAPI for component tests
+      mockElectronAPI = {
+        onHttpServerTaskCreated: vi.fn(),
+        removeHttpServerTaskCreatedListener: vi.fn()
+      }
+      ;(global as any).window.electronAPI = mockElectronAPI
+    })
+
+    afterEach(() => {
+      if ((global as any).window && (global as any).window.electronAPI) {
+        delete (global as any).window.electronAPI
+      }
+    })
+
+    it('should register HTTP server event listener on component mount', async () => {
+      const TestComponent = defineComponent({
+        setup() {
+          const selectedDate = ref(new Date())
+          const mockCallback = vi.fn()
+          const { startAutoRefresh, stopAutoRefresh } = useAutoRefresh(selectedDate, mockCallback)
+
+          return { selectedDate, mockCallback, startAutoRefresh, stopAutoRefresh }
+        },
+        template: '<div>Test Component</div>'
+      })
+
+      const wrapper = mount(TestComponent)
+
+      // Verify onMounted was called and registered the event listener
+      expect(mockElectronAPI.onHttpServerTaskCreated).toHaveBeenCalledTimes(1)
+      expect(typeof mockElectronAPI.onHttpServerTaskCreated.mock.calls[0][0]).toBe('function')
+
+      wrapper.unmount()
+    })
+
+    it('should clean up HTTP server event listener on component unmount', async () => {
+      const TestComponent = defineComponent({
+        setup() {
+          const selectedDate = ref(new Date())
+          const mockCallback = vi.fn()
+          const composable = useAutoRefresh(selectedDate, mockCallback)
+          return { selectedDate, mockCallback, ...composable }
+        },
+        template: '<div>Test Component</div>'
+      })
+
+      const wrapper = mount(TestComponent)
+
+      // Get the registered handler
+      const registeredHandler = mockElectronAPI.onHttpServerTaskCreated.mock.calls[0][0]
+
+      // Unmount the component to trigger onUnmounted
+      wrapper.unmount()
+
+      // Verify cleanup was called
+      expect(mockElectronAPI.removeHttpServerTaskCreatedListener).toHaveBeenCalledTimes(1)
+      expect(mockElectronAPI.removeHttpServerTaskCreatedListener).toHaveBeenCalledWith(registeredHandler)
+    })
+
+    it('should handle HTTP task creation events through actual event listener', async () => {
+      const mockCallback = vi.fn()
+
+      const TestComponent = defineComponent({
+        setup() {
+          const selectedDate = ref(new Date())
+          const composable = useAutoRefresh(selectedDate, mockCallback)
+          return { selectedDate, mockCallback, ...composable }
+        },
+        template: '<div>Test Component</div>'
+      })
+
+      const wrapper = mount(TestComponent)
+
+      // Get the registered handler
+      const registeredHandler = mockElectronAPI.onHttpServerTaskCreated.mock.calls[0][0]
+
+      // Set today's date
+      const today = new Date()
+      wrapper.vm.selectedDate = today
+      const todayString = today.toISOString().split('T')[0]
+
+      // Trigger the actual event handler
+      registeredHandler({ date: todayString })
+
+      expect(mockCallback).toHaveBeenCalledTimes(1)
+
+      wrapper.unmount()
+    })
+
+    it('should handle missing window.setInterval gracefully in component', async () => {
+      // Set up window without setInterval to test the specific window method access
+      const originalWindow = (global as any).window
+      ;(global as any).window = {}
+
+      const TestComponent = defineComponent({
+        setup() {
+          const selectedDate = ref(new Date())
+          const mockCallback = vi.fn()
+          const { startAutoRefresh, stopAutoRefresh } = useAutoRefresh(selectedDate, mockCallback)
+
+          return { selectedDate, mockCallback, startAutoRefresh, stopAutoRefresh }
+        },
+        template: '<div>Test Component</div>'
+      })
+
+      const wrapper = mount(TestComponent)
+
+      // This should not throw during component mount, but startAutoRefresh might fail
+      expect(() => {
+        wrapper.vm.startAutoRefresh()
+      }).toThrow() // Expected to throw when window.setInterval is not available
+
+      wrapper.unmount()
+
+      // Restore window object
+      ;(global as any).window = originalWindow
+    })
+
+    it('should handle missing electronAPI methods in component', async () => {
+      // Set up electronAPI without required methods
+      ;(global as any).window.electronAPI = {}
+
+      expect(() => {
+        const TestComponent = defineComponent({
+          setup() {
+            const selectedDate = ref(new Date())
+            const mockCallback = vi.fn()
+            return useAutoRefresh(selectedDate, mockCallback)
+          },
+          template: '<div>Test Component</div>'
+        })
+
+        const wrapper = mount(TestComponent)
+        wrapper.unmount()
+      }).not.toThrow()
+    })
+  })
+
+  describe('Edge Cases and Error Handling', () => {
+    it('should handle stopAutoRefresh when interval is already null', () => {
+      const { stopAutoRefresh } = scope.run(() => useAutoRefresh(selectedDate, mockCallback))!
+
+      // Call stopAutoRefresh when no interval is running
+      expect(() => {
+        stopAutoRefresh()
+        stopAutoRefresh() // Call again to test null check
+      }).not.toThrow()
+    })
+
+    it('should handle startAutoRefresh when already running', () => {
+      const { startAutoRefresh, stopAutoRefresh } = scope.run(() => useAutoRefresh(selectedDate, mockCallback))!
+
+      startAutoRefresh()
+
+      // Try to start again - should return early without creating another interval
+      startAutoRefresh()
+
+      // Should still only have one interval running
+      vi.advanceTimersByTime(15000)
+      expect(mockCallback).toHaveBeenCalledTimes(1)
+
+      stopAutoRefresh()
+    })
+
+    it('should handle watch callback reactivity properly', () => {
+      const { startAutoRefresh, stopAutoRefresh } = scope.run(() => useAutoRefresh(selectedDate, mockCallback))!
+
+      startAutoRefresh()
+
+      // Change date - should trigger watcher and restart
+      const tomorrow = new Date()
+      tomorrow.setDate(tomorrow.getDate() + 1)
+      selectedDate.value = tomorrow
+
+      // Should have stopped auto-refresh since tomorrow is not today
+      vi.advanceTimersByTime(15000)
+      expect(mockCallback).not.toHaveBeenCalled()
 
       stopAutoRefresh()
     })

--- a/src/composables/useAutoRefresh.test.ts
+++ b/src/composables/useAutoRefresh.test.ts
@@ -167,7 +167,7 @@ describe('useAutoRefresh', () => {
 
       // Simulate the HTTP task created handler directly since onMounted doesn't fire in tests
       const handleHttpTaskCreated = (data: any) => {
-        const currentDateString = selectedDate.value.toISOString().split('T')[0]
+        const currentDateString = formatLocalDateString(selectedDate.value)
 
         // Only refresh if the task was created for the currently viewed date
         if (data.date === currentDateString) {
@@ -182,7 +182,7 @@ describe('useAutoRefresh', () => {
       // Set today's date
       const today = new Date()
       selectedDate.value = today
-      const todayString = today.toISOString().split('T')[0]
+      const todayString = formatLocalDateString(today)
 
       // Simulate HTTP task creation for today
       handleHttpTaskCreated({ date: todayString })
@@ -195,7 +195,7 @@ describe('useAutoRefresh', () => {
 
       // Simulate the HTTP task created handler directly
       const handleHttpTaskCreated = (data: any) => {
-        const currentDateString = selectedDate.value.toISOString().split('T')[0]
+        const currentDateString = formatLocalDateString(selectedDate.value)
 
         if (data.date === currentDateString) {
           try {
@@ -226,7 +226,7 @@ describe('useAutoRefresh', () => {
 
       // Simulate the HTTP task created handler directly
       const handleHttpTaskCreated = (data: any) => {
-        const currentDateString = selectedDate.value.toISOString().split('T')[0]
+        const currentDateString = formatLocalDateString(selectedDate.value)
 
         if (data.date === currentDateString) {
           try {
@@ -240,7 +240,7 @@ describe('useAutoRefresh', () => {
       // Set today's date
       const today = new Date()
       selectedDate.value = today
-      const todayString = today.toISOString().split('T')[0]
+      const todayString = formatLocalDateString(today)
 
       // Simulate HTTP task creation with error
       handleHttpTaskCreated({ date: todayString })
@@ -413,7 +413,7 @@ describe('useAutoRefresh', () => {
       // Set today's date
       const today = new Date()
       wrapper.vm.selectedDate = today
-      const todayString = today.toISOString().split('T')[0]
+      const todayString = formatLocalDateString(today)
 
       // Trigger the actual event handler
       registeredHandler({ date: todayString })

--- a/src/composables/useSettings.httpServer.test.ts
+++ b/src/composables/useSettings.httpServer.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useSettings } from './useSettings'
+
+describe('useSettings HTTP Server functionality', () => {
+  let localStorageMock: Record<string, string | undefined>
+  let setItemSpy: any
+  let getItemSpy: any
+  let removeItemSpy: any
+
+  beforeEach(() => {
+    localStorageMock = {}
+    setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation((k, v) => {
+      localStorageMock[k] = v
+    })
+    getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(k => localStorageMock[k] ?? null)
+    removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(k => {
+      delete localStorageMock[k]
+    })
+
+    // Mock matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn()
+      }))
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('default values', () => {
+    it('should have correct default HTTP server settings', () => {
+      const { httpServerEnabled, httpServerPort, tempHttpServerEnabled, tempHttpServerPort } = useSettings()
+
+      expect(httpServerEnabled.value).toBe(false)
+      expect(httpServerPort.value).toBe(14474)
+      expect(tempHttpServerEnabled.value).toBe(false)
+      expect(tempHttpServerPort.value).toBe(14474)
+    })
+  })
+
+  describe('loading from localStorage', () => {
+    it('should load HTTP server enabled setting from localStorage', () => {
+      localStorageMock['httpServerEnabled'] = 'true'
+
+      const { httpServerEnabled, loadSettings } = useSettings()
+      loadSettings()
+      expect(httpServerEnabled.value).toBe(true)
+    })
+
+    it('should load HTTP server port from localStorage', () => {
+      localStorageMock['httpServerPort'] = '8080'
+
+      const { httpServerPort, loadSettings } = useSettings()
+      loadSettings()
+      expect(httpServerPort.value).toBe(8080)
+    })
+
+    it('should reject invalid HTTP server enabled values', () => {
+      localStorageMock['httpServerEnabled'] = 'maybe'
+
+      const { httpServerEnabled, loadSettings } = useSettings()
+      loadSettings()
+      expect(httpServerEnabled.value).toBe(false) // Should keep default
+    })
+
+    it('should reject invalid HTTP server ports', () => {
+      localStorageMock['httpServerPort'] = '80' // Below 1024
+
+      const { httpServerPort, loadSettings } = useSettings()
+      loadSettings()
+      expect(httpServerPort.value).toBe(14474) // Should keep default
+    })
+  })
+
+  describe('port validation', () => {
+    it('should validate HTTP ports correctly', () => {
+      const { isValidHttpPort } = useSettings()
+
+      // Valid ports
+      expect(isValidHttpPort(1024)).toBe(true)
+      expect(isValidHttpPort(8080)).toBe(true)
+      expect(isValidHttpPort(65535)).toBe(true)
+      expect(isValidHttpPort(14474)).toBe(true)
+
+      // Invalid ports
+      expect(isValidHttpPort(1023)).toBe(false)
+      expect(isValidHttpPort(65536)).toBe(false)
+      expect(isValidHttpPort(0)).toBe(false)
+      expect(isValidHttpPort(-1)).toBe(false)
+
+      // Invalid types
+      expect(isValidHttpPort('8080')).toBe(false)
+      expect(isValidHttpPort(null)).toBe(false)
+      expect(isValidHttpPort(undefined)).toBe(false)
+      expect(isValidHttpPort(8080.5)).toBe(false)
+    })
+  })
+
+  describe('saving settings', () => {
+    it('should save valid HTTP server settings', () => {
+      const { tempHttpServerEnabled, tempHttpServerPort, saveSettings } = useSettings()
+
+      tempHttpServerEnabled.value = true
+      tempHttpServerPort.value = 8080
+
+      saveSettings()
+
+      expect(setItemSpy).toHaveBeenCalledWith('httpServerEnabled', 'true')
+      expect(setItemSpy).toHaveBeenCalledWith('httpServerPort', '8080')
+    })
+
+    it('should handle invalid HTTP server port during save', () => {
+      const { tempHttpServerPort, httpServerPort, saveSettings } = useSettings()
+
+      tempHttpServerPort.value = 80 // Invalid port
+
+      saveSettings()
+
+      // Should keep default valid port
+      expect(httpServerPort.value).toBe(14474)
+      expect(setItemSpy).toHaveBeenCalledWith('httpServerPort', '14474')
+    })
+  })
+
+  describe('initialization', () => {
+    it('should initialize temp settings correctly', () => {
+      const { httpServerEnabled, httpServerPort, tempHttpServerEnabled, tempHttpServerPort, initializeTempSettings } =
+        useSettings()
+
+      httpServerEnabled.value = true
+      httpServerPort.value = 8080
+
+      initializeTempSettings()
+
+      expect(tempHttpServerEnabled.value).toBe(true)
+      expect(tempHttpServerPort.value).toBe(8080)
+    })
+  })
+
+  describe('settings restoration', () => {
+    it('should restore HTTP server settings from backup', () => {
+      const { httpServerEnabled, httpServerPort, applyRestoredSettings } = useSettings()
+
+      const restoredSettings = {
+        theme: 'dark' as const,
+        targetWorkHours: 8,
+        reportingAppButtonText: 'Test',
+        reportingAppUrl: '',
+        evictionEnabled: true,
+        evictionDaysToKeep: 180,
+        httpServerEnabled: true,
+        httpServerPort: 8080
+      }
+
+      applyRestoredSettings(restoredSettings)
+
+      expect(httpServerEnabled.value).toBe(true)
+      expect(httpServerPort.value).toBe(8080)
+      expect(setItemSpy).toHaveBeenCalledWith('httpServerEnabled', 'true')
+      expect(setItemSpy).toHaveBeenCalledWith('httpServerPort', '8080')
+    })
+
+    it('should reject invalid HTTP server settings during restoration', () => {
+      const { httpServerEnabled, httpServerPort, applyRestoredSettings } = useSettings()
+
+      const invalidSettings = {
+        theme: 'dark' as const,
+        targetWorkHours: 8,
+        reportingAppButtonText: 'Test',
+        reportingAppUrl: '',
+        evictionEnabled: true,
+        evictionDaysToKeep: 180,
+        httpServerEnabled: 'maybe' as any, // Invalid
+        httpServerPort: 80 // Invalid
+      }
+
+      applyRestoredSettings(invalidSettings)
+
+      expect(httpServerEnabled.value).toBe(false) // Should keep default
+      expect(httpServerPort.value).toBe(14474) // Should keep default
+    })
+  })
+})

--- a/src/main/httpServer.test.ts
+++ b/src/main/httpServer.test.ts
@@ -218,7 +218,7 @@ describe('HttpServerManager', () => {
       expect(dbCall.category_name).toBe('Default')
       expect(dbCall.task_type).toBe('normal')
       expect(dbCall.date).toMatch(/^\d{4}-\d{2}-\d{2}$/) // YYYY-MM-DD format
-      expect(dbCall.start_time).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/) // ISO timestamp
+      expect(dbCall.start_time).toMatch(/^\d{2}:\d{2}$/) // HH:mm local time
 
       // Verify taskCreated event was emitted
       expect(taskCreatedHandler).toHaveBeenCalledTimes(1)

--- a/src/main/httpServer.test.ts
+++ b/src/main/httpServer.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { httpServerManager } from './httpServer'
+import { dbService } from './database'
+
+// Mock the database service
+vi.mock('./database', () => ({
+  dbService: {
+    getDefaultCategory: vi.fn(),
+    addTaskRecord: vi.fn()
+  }
+}))
+
+describe('HttpServerManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(async () => {
+    // Ensure server is stopped after each test
+    await httpServerManager.stop()
+  })
+
+  describe('port validation', () => {
+    it('should reject ports below 1024', async () => {
+      const result = await httpServerManager.start(1023)
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Port must be between 1024 and 65535')
+    })
+
+    it('should reject ports above 65535', async () => {
+      const result = await httpServerManager.start(65536)
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Port must be between 1024 and 65535')
+    })
+
+    it('should accept valid ports', async () => {
+      // Use a port that's likely to be available for testing
+      const testPort = 14474
+      const result = await httpServerManager.start(testPort)
+
+      // The test might fail if port is in use, which is acceptable
+      if (result.success) {
+        expect(result.port).toBe(testPort)
+        expect(httpServerManager.getStatus().running).toBe(true)
+      }
+    })
+  })
+
+  describe('server lifecycle', () => {
+    it('should start and stop server correctly', async () => {
+      const testPort = 14475
+
+      // Initially not running
+      expect(httpServerManager.getStatus().running).toBe(false)
+
+      // Start server
+      const startResult = await httpServerManager.start(testPort)
+      if (startResult.success) {
+        expect(httpServerManager.getStatus().running).toBe(true)
+        expect(httpServerManager.getStatus().port).toBe(testPort)
+
+        // Stop server
+        await httpServerManager.stop()
+        expect(httpServerManager.getStatus().running).toBe(false)
+        expect(httpServerManager.getStatus().port).toBeUndefined()
+      }
+    })
+
+    it('should handle starting server on occupied port', async () => {
+      const testPort = 14476
+
+      // Start first instance
+      const firstResult = await httpServerManager.start(testPort)
+      if (firstResult.success) {
+        // Try to start second instance on same port (this will fail because we're reusing the same manager)
+        // In real scenario, this would be testing port conflict
+        const secondResult = await httpServerManager.start(testPort)
+        expect(secondResult.success).toBe(true) // Manager stops the first and starts new one
+      }
+    })
+  })
+
+  describe('status reporting', () => {
+    it('should report correct status when stopped', () => {
+      const status = httpServerManager.getStatus()
+      expect(status.running).toBe(false)
+      expect(status.port).toBeUndefined()
+      expect(status.error).toBeUndefined()
+    })
+
+    it('should report correct status when running', async () => {
+      const testPort = 14477
+      const result = await httpServerManager.start(testPort)
+
+      if (result.success) {
+        const status = httpServerManager.getStatus()
+        expect(status.running).toBe(true)
+        expect(status.port).toBe(testPort)
+        expect(status.error).toBeUndefined()
+      }
+    })
+  })
+
+  describe('event emission', () => {
+    it('should emit started event when server starts', async () => {
+      const testPort = 14478
+      const startedHandler = vi.fn()
+
+      httpServerManager.on('started', startedHandler)
+
+      const result = await httpServerManager.start(testPort)
+      if (result.success) {
+        expect(startedHandler).toHaveBeenCalledWith(testPort)
+      }
+
+      httpServerManager.removeListener('started', startedHandler)
+    })
+
+    it('should emit stopped event when server stops', async () => {
+      const testPort = 14479
+      const stoppedHandler = vi.fn()
+
+      const result = await httpServerManager.start(testPort)
+      if (result.success) {
+        httpServerManager.on('stopped', stoppedHandler)
+        await httpServerManager.stop()
+        expect(stoppedHandler).toHaveBeenCalled()
+        httpServerManager.removeListener('stopped', stoppedHandler)
+      }
+    })
+  })
+
+  describe('task creation handling', () => {
+    beforeEach(() => {
+      // Mock successful database operations
+      vi.mocked(dbService.getDefaultCategory).mockResolvedValue({
+        id: 1,
+        name: 'Default',
+        is_default: true
+      })
+      vi.mocked(dbService.addTaskRecord).mockResolvedValue({
+        id: 1,
+        category_name: 'Default',
+        task_name: 'Test Task',
+        start_time: '2023-01-01T12:00:00.000Z',
+        date: '2023-01-01',
+        task_type: 'normal'
+      })
+    })
+
+    it('should emit taskCreated event when task is successfully created', async () => {
+      const testPort = 14480
+      const taskCreatedHandler = vi.fn()
+
+      httpServerManager.on('taskCreated', taskCreatedHandler)
+
+      const result = await httpServerManager.start(testPort)
+      if (result.success) {
+        // This would normally be tested with actual HTTP requests
+        // For unit testing, we're just verifying the event emission setup
+        expect(httpServerManager.listenerCount('taskCreated')).toBe(1)
+      }
+
+      httpServerManager.removeListener('taskCreated', taskCreatedHandler)
+    })
+  })
+})

--- a/src/main/httpServer.ts
+++ b/src/main/httpServer.ts
@@ -1,0 +1,183 @@
+import { createServer, IncomingMessage, ServerResponse, Server } from 'http'
+import { URL } from 'url'
+import { EventEmitter } from 'events'
+import { dbService } from './database'
+import type { TaskRecordInsert, HttpServerStatus, HttpServerStartResult } from '../shared/types'
+
+export class HttpServerManager extends EventEmitter {
+  private server: Server | null = null
+  private port: number | null = null
+  private error: string | null = null
+
+  /**
+   * Start the HTTP server on the specified port
+   */
+  async start(port: number): Promise<HttpServerStartResult> {
+    // Stop existing server if running
+    if (this.server) {
+      await this.stop()
+    }
+
+    // Validate port range (unprivileged ports)
+    if (!this.isValidPort(port)) {
+      const error = 'Port must be between 1024 and 65535'
+      this.error = error
+      return { success: false, error }
+    }
+
+    return new Promise(resolve => {
+      this.server = createServer((req, res) => this.handleRequest(req, res))
+
+      // Handle server errors
+      this.server.on('error', (err: any) => {
+        const error = `Failed to start server: ${err.message}`
+        this.error = error
+        this.emit('error', error)
+        resolve({ success: false, error })
+      })
+
+      // Start listening on localhost only
+      this.server.listen(port, '127.0.0.1', () => {
+        this.port = port
+        this.error = null
+        this.emit('started', port)
+        resolve({ success: true, port })
+      })
+    })
+  }
+
+  /**
+   * Stop the HTTP server
+   */
+  async stop(): Promise<void> {
+    if (!this.server) {
+      return
+    }
+
+    return new Promise(resolve => {
+      this.server!.close(() => {
+        this.server = null
+        this.port = null
+        this.error = null
+        this.emit('stopped')
+        resolve()
+      })
+    })
+  }
+
+  /**
+   * Get current server status
+   */
+  getStatus(): HttpServerStatus {
+    return {
+      running: this.server !== null && this.port !== null,
+      port: this.port || undefined,
+      error: this.error || undefined
+    }
+  }
+
+  /**
+   * Validate port number
+   */
+  private isValidPort(port: number): boolean {
+    return Number.isInteger(port) && port >= 1024 && port <= 65535
+  }
+
+  /**
+   * Handle incoming HTTP requests
+   */
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // Set CORS headers for localhost requests
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.setHeader('Access-Control-Allow-Methods', 'GET')
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+
+    // Only handle GET requests
+    if (req.method !== 'GET') {
+      this.sendError(res, 405, 'Method not allowed')
+      return
+    }
+
+    // Parse URL and query parameters
+    const url = new URL(req.url || '', `http://127.0.0.1:${this.port}`)
+
+    // Handle /create-task endpoint
+    if (url.pathname === '/create-task') {
+      await this.handleCreateTask(url.searchParams, res)
+      return
+    }
+
+    // Handle root path with simple response
+    if (url.pathname === '/') {
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
+      res.end('TimeCatcher HTTP Server is running')
+      return
+    }
+
+    // Unknown endpoint
+    this.sendError(res, 404, 'Not found')
+  }
+
+  /**
+   * Handle create task endpoint
+   */
+  private async handleCreateTask(params: URLSearchParams, res: ServerResponse): Promise<void> {
+    try {
+      // Get required task parameter
+      const taskName = params.get('task')
+      if (!taskName || taskName.trim() === '') {
+        this.sendError(res, 400, 'Missing required parameter: task')
+        return
+      }
+
+      // Get optional category parameter or use default
+      let categoryName = params.get('category')
+      if (!categoryName || categoryName.trim() === '') {
+        const defaultCategory = await dbService.getDefaultCategory()
+        if (!defaultCategory) {
+          this.sendError(res, 400, 'No category specified and no default category set')
+          return
+        }
+        categoryName = defaultCategory.name
+      }
+
+      // Create current timestamp and date
+      const now = new Date()
+      const startTime = now.toISOString()
+      const date = now.toISOString().split('T')[0] // YYYY-MM-DD format
+
+      // Create task record
+      const taskRecord: TaskRecordInsert = {
+        category_name: categoryName.trim(),
+        task_name: taskName.trim(),
+        start_time: startTime,
+        date,
+        task_type: 'normal'
+      }
+
+      // Add to database
+      await dbService.addTaskRecord(taskRecord)
+
+      // Emit event for UI refresh
+      this.emit('taskCreated', { date, taskRecord })
+
+      // Send success response (204 No Content)
+      res.writeHead(204)
+      res.end()
+    } catch (error) {
+      console.error('Error creating task via HTTP:', error)
+      this.sendError(res, 500, 'Internal server error')
+    }
+  }
+
+  /**
+   * Send error response
+   */
+  private sendError(res: ServerResponse, statusCode: number, message: string): void {
+    res.writeHead(statusCode, { 'Content-Type': 'text/plain' })
+    res.end(message)
+  }
+}
+
+// Export singleton instance
+export const httpServerManager = new HttpServerManager()

--- a/src/main/httpServer.ts
+++ b/src/main/httpServer.ts
@@ -147,7 +147,10 @@ export class HttpServerManager extends EventEmitter {
       const month = String(now.getMonth() + 1).padStart(2, '0')
       const day = String(now.getDate()).padStart(2, '0')
       const date = `${year}-${month}-${day}` // YYYY-MM-DD (local date)
-      const startTime = now.toISOString() // ISO timestamp with milliseconds (UTC)
+      // Use HH:mm local time to match manual task entry behavior in the renderer
+      const hours = String(now.getHours()).padStart(2, '0')
+      const minutes = String(now.getMinutes()).padStart(2, '0')
+      const startTime = `${hours}:${minutes}`
 
       // Create task record
       const taskRecord: TaskRecordInsert = {

--- a/src/main/httpServer.ts
+++ b/src/main/httpServer.ts
@@ -143,8 +143,11 @@ export class HttpServerManager extends EventEmitter {
 
       // Create current timestamp and date
       const now = new Date()
-      const startTime = now.toISOString()
-      const date = now.toISOString().split('T')[0] // YYYY-MM-DD format
+      const year = now.getFullYear()
+      const month = String(now.getMonth() + 1).padStart(2, '0')
+      const day = String(now.getDate()).padStart(2, '0')
+      const date = `${year}-${month}-${day}` // YYYY-MM-DD (local date)
+      const startTime = now.toISOString() // ISO timestamp with milliseconds (UTC)
 
       // Create task record
       const taskRecord: TaskRecordInsert = {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,10 +1,29 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import type { TaskRecordInsert, TaskRecordUpdate, SettingsSnapshot, BackupResult, RestoreResult } from '../shared/types'
+import type {
+  TaskRecordInsert,
+  TaskRecordUpdate,
+  SettingsSnapshot,
+  BackupResult,
+  RestoreResult,
+  HttpServerStartResult,
+  HttpServerStatus
+} from '../shared/types'
 
 contextBridge.exposeInMainWorld('electronAPI', {
   // Application info
   getVersion: (): Promise<string> => ipcRenderer.invoke('app:get-version'),
   openExternalUrl: (url: string): Promise<boolean> => ipcRenderer.invoke('app:open-external-url', url),
+
+  // HTTP Server
+  startHttpServer: (port: number): Promise<HttpServerStartResult> => ipcRenderer.invoke('http-server:start', port),
+  stopHttpServer: (): Promise<void> => ipcRenderer.invoke('http-server:stop'),
+  getHttpServerStatus: (): Promise<HttpServerStatus> => ipcRenderer.invoke('http-server:status'),
+  onHttpServerTaskCreated: (callback: (data: any) => void) => {
+    ipcRenderer.on('http-server:task-created', (_, data) => callback(data))
+  },
+  removeHttpServerTaskCreatedListener: (callback: (data: any) => void) => {
+    ipcRenderer.removeListener('http-server:task-created', callback)
+  },
 
   // Database operations
   getCategories: () => ipcRenderer.invoke('db:get-categories'),

--- a/src/main/restore.integration.test.ts
+++ b/src/main/restore.integration.test.ts
@@ -35,6 +35,7 @@ vi.mock('electron', () => {
       loadURL() {}
       loadFile() {}
       webContents = { openDevTools() {} }
+      on() {} // Add missing event listener method
       constructor(_: any) {}
     },
     ipcMain: {

--- a/src/main/validation.test.ts
+++ b/src/main/validation.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from 'vitest'
-import { validateCutoffDate } from './validation'
+import { validateCutoffDate, validateHttpPort } from './validation'
 
 describe('validateCutoffDate', () => {
   describe('Input validation', () => {
@@ -134,5 +134,39 @@ describe('validateCutoffDate', () => {
 
       expect(result).toBe(dateOnly)
     })
+  })
+})
+
+describe('validateHttpPort', () => {
+  it('should accept valid ports in unprivileged range', () => {
+    expect(validateHttpPort(1024)).toBe(1024)
+    expect(validateHttpPort(8080)).toBe(8080)
+    expect(validateHttpPort(65535)).toBe(65535)
+    expect(validateHttpPort(14474)).toBe(14474)
+  })
+
+  it('should reject ports below 1024', () => {
+    expect(() => validateHttpPort(1023)).toThrow('Invalid port: must be between 1024 and 65535')
+    expect(() => validateHttpPort(80)).toThrow('Invalid port: must be between 1024 and 65535')
+    expect(() => validateHttpPort(0)).toThrow('Invalid port: must be between 1024 and 65535')
+  })
+
+  it('should reject ports above 65535', () => {
+    expect(() => validateHttpPort(65536)).toThrow('Invalid port: must be between 1024 and 65535')
+    expect(() => validateHttpPort(99999)).toThrow('Invalid port: must be between 1024 and 65535')
+  })
+
+  it('should reject non-integer values', () => {
+    expect(() => validateHttpPort(1024.5)).toThrow('Invalid port: must be an integer')
+    expect(() => validateHttpPort('1024' as any)).toThrow('Invalid port: must be an integer')
+    expect(() => validateHttpPort(null as any)).toThrow('Invalid port: must be an integer')
+    expect(() => validateHttpPort(undefined as any)).toThrow('Invalid port: must be an integer')
+    expect(() => validateHttpPort({} as any)).toThrow('Invalid port: must be an integer')
+  })
+
+  it('should reject NaN and Infinity', () => {
+    expect(() => validateHttpPort(NaN)).toThrow('Invalid port: must be an integer')
+    expect(() => validateHttpPort(Infinity)).toThrow('Invalid port: must be an integer')
+    expect(() => validateHttpPort(-Infinity)).toThrow('Invalid port: must be an integer')
   })
 })

--- a/src/main/validation.ts
+++ b/src/main/validation.ts
@@ -42,3 +42,17 @@ export function validateCutoffDate(cutoffDate: unknown): string {
   // Return the validated string
   return cutoffDate
 }
+
+export function validateHttpPort(port: unknown): number {
+  // Ensure port is a number
+  if (typeof port !== 'number' || !Number.isInteger(port)) {
+    throw new Error('Invalid port: must be an integer')
+  }
+
+  // Validate port range (unprivileged user ports)
+  if (port < 1024 || port > 65535) {
+    throw new Error('Invalid port: must be between 1024 and 65535 (unprivileged range)')
+  }
+
+  return port
+}

--- a/src/renderer/App.test.ts
+++ b/src/renderer/App.test.ts
@@ -25,6 +25,9 @@ function createElectronAPIMock(overrides?: Partial<typeof global.window.electron
     // App operations
     getVersion: vi.fn().mockResolvedValue('1.0.0'),
     openExternalUrl: vi.fn(),
+    // HTTP server operations
+    startHttpServer: vi.fn().mockResolvedValue({ success: true, port: 14474 }),
+    stopHttpServer: vi.fn().mockResolvedValue(undefined),
     // Backup & restore operations
     backupApp: vi.fn(),
     restoreApp: vi.fn(),
@@ -240,7 +243,17 @@ vi.mock('@/composables/useSettings', () => ({
     reportingAppUrl: ref(''),
     tempReportingAppButtonText: ref('Tempo'),
     tempReportingAppUrl: ref(''),
+    evictionEnabled: ref(true),
+    tempEvictionEnabled: ref(true),
+    evictionDaysToKeep: ref(180),
+    tempEvictionDaysToKeep: ref(180),
+    httpServerEnabled: ref(false),
+    tempHttpServerEnabled: ref(false),
+    httpServerPort: ref(14474),
+    tempHttpServerPort: ref(14474),
     isValidUrl: mockIsValidUrl,
+    isValidEvictionDaysToKeep: vi.fn(() => true),
+    isValidHttpPort: vi.fn(() => true),
     applyTheme: mockApplyTheme,
     saveSettings: mockSaveSettings,
     initializeTempSettings: mockInitializeTempSettings,

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -281,7 +281,9 @@ const { sortedTaskRecords, calculateDuration, getTotalMinutesTracked, getCategor
 
 const { startAutoRefresh, stopAutoRefresh, restartAutoRefresh } = useAutoRefresh(selectedDate, () => {
   updateContext.value = 'auto-refresh'
-  taskRecords.value = [...taskRecords.value] // Trigger reactivity
+  // Reload tasks from the database to include newly added entries (e.g., via HTTP server)
+  // Intentionally not awaited; useAutoRefresh wraps calls in try/catch
+  void loadTaskRecords()
 })
 
 // Media query references for cleanup

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -80,8 +80,11 @@
       :temp-reporting-app-url="tempReportingAppUrl"
       :temp-eviction-enabled="tempEvictionEnabled"
       :temp-eviction-days-to-keep="tempEvictionDaysToKeep"
+      :temp-http-server-enabled="tempHttpServerEnabled"
+      :temp-http-server-port="tempHttpServerPort"
       :is-valid-url="isValidUrl"
       :is-valid-eviction-days-to-keep="isValidEvictionDaysToKeep"
+      :is-valid-http-port="isValidHttpPort"
       :categories="categories"
       :is-loading-categories="isLoadingCategories"
       :is-adding-category="isAddingCategory"
@@ -99,6 +102,8 @@
       @update-temp-reporting-app-url="url => (tempReportingAppUrl = url)"
       @update-temp-eviction-enabled="enabled => (tempEvictionEnabled = enabled)"
       @update-temp-eviction-days-to-keep="days => (tempEvictionDaysToKeep = days)"
+      @update-temp-http-server-enabled="enabled => (tempHttpServerEnabled = enabled)"
+      @update-temp-http-server-port="port => (tempHttpServerPort = port)"
       @start-edit-category="startEditCategory"
       @update-editing-category-name="name => (editingCategoryName = name)"
       @save-edit-category="saveEditCategory"
@@ -258,8 +263,13 @@ const {
   tempEvictionEnabled,
   evictionDaysToKeep,
   tempEvictionDaysToKeep,
+  httpServerEnabled,
+  httpServerPort,
+  tempHttpServerEnabled,
+  tempHttpServerPort,
   isValidUrl,
   isValidEvictionDaysToKeep,
+  isValidHttpPort,
   applyTheme,
   saveSettings: saveSettingsComposable,
   initializeTempSettings,
@@ -446,8 +456,57 @@ const closeSetupModal = () => {
 }
 
 const saveSettings = () => {
+  // Store previous HTTP server settings for comparison (with defensive checks for tests)
+  const previousHttpEnabled = httpServerEnabled?.value ?? false
+  const previousHttpPort = httpServerPort?.value ?? 14474
+
+  // Save settings (this will update the reactive refs)
   saveSettingsComposable()
+
+  // Handle HTTP server configuration changes in background
+  handleHttpServerConfigChange(previousHttpEnabled, previousHttpPort)
+
   closeSetupModal()
+}
+
+/**
+ * Handle HTTP server configuration changes after settings save
+ */
+const handleHttpServerConfigChange = async (previousEnabled: boolean, previousPort: number) => {
+  const currentEnabled = httpServerEnabled?.value ?? false
+  const currentPort = httpServerPort?.value ?? 14474
+
+  // Check if HTTP server settings have changed
+  const enabledChanged = previousEnabled !== currentEnabled
+  const portChanged = previousPort !== currentPort
+
+  if (!enabledChanged && !portChanged) {
+    // No HTTP server changes, nothing to do
+    return
+  }
+
+  try {
+    // Stop existing server if it was running
+    if (previousEnabled && window?.electronAPI?.stopHttpServer) {
+      await window.electronAPI.stopHttpServer()
+    }
+
+    // Start server with new configuration if enabled
+    if (currentEnabled && window?.electronAPI?.startHttpServer) {
+      const result = await window.electronAPI.startHttpServer(currentPort)
+      if (!result.success) {
+        console.error(`Failed to start HTTP server: ${result.error}`)
+        showToastMessage(`Failed to start HTTP server: ${result.error}`, 'error')
+      } else {
+        showToastMessage(`HTTP server started on port ${currentPort}`, 'success')
+      }
+    } else if (!currentEnabled) {
+      showToastMessage('HTTP server disabled', 'info')
+    }
+  } catch (error) {
+    console.error('Error handling HTTP server configuration change:', error)
+    showToastMessage('Error configuring HTTP server', 'error')
+  }
 }
 
 // Backup & Restore handlers
@@ -462,7 +521,9 @@ const backupApp = async () => {
     reportingAppButtonText: reportingAppButtonText.value,
     reportingAppUrl: reportingAppUrl.value,
     evictionEnabled: evictionEnabled?.value ?? true,
-    evictionDaysToKeep: evictionDaysToKeep?.value ?? 180
+    evictionDaysToKeep: evictionDaysToKeep?.value ?? 180,
+    httpServerEnabled: httpServerEnabled?.value ?? false,
+    httpServerPort: httpServerPort?.value ?? 14474
   }
   try {
     const res = await window.electronAPI.backupApp(settings)
@@ -823,6 +884,20 @@ onMounted(async () => {
   // Start auto-refresh for today's tasks
   if (isToday.value) {
     startAutoRefresh()
+  }
+
+  // Start HTTP server if enabled
+  if (httpServerEnabled.value) {
+    try {
+      if (typeof window !== 'undefined' && (window as any).electronAPI?.startHttpServer) {
+        const result = await (window as any).electronAPI.startHttpServer(httpServerPort.value)
+        if (!result.success) {
+          console.error(`Failed to start HTTP server: ${result.error}`)
+        }
+      }
+    } catch (error) {
+      console.error('Error starting HTTP server:', error)
+    }
   }
 
   // Fetch app version

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -58,6 +58,8 @@ export interface SettingsSnapshot {
   reportingAppUrl: string
   evictionEnabled: boolean
   evictionDaysToKeep: number
+  httpServerEnabled: boolean
+  httpServerPort: number
 }
 
 // IPC result types for backup/restore flows
@@ -74,6 +76,19 @@ export interface RestoreResult {
   settings?: Partial<SettingsSnapshot>
 }
 
+// HTTP Server types
+export interface HttpServerStatus {
+  running: boolean
+  port?: number
+  error?: string
+}
+
+export interface HttpServerStartResult {
+  success: boolean
+  error?: string
+  port?: number
+}
+
 export interface ElectronAPI {
   // Application info
   getVersion: () => Promise<string>
@@ -81,6 +96,12 @@ export interface ElectronAPI {
   // Backup & Restore
   backupApp?: (settings: SettingsSnapshot) => Promise<BackupResult>
   restoreApp?: () => Promise<RestoreResult>
+  // HTTP Server
+  startHttpServer?: (port: number) => Promise<HttpServerStartResult>
+  stopHttpServer?: () => Promise<void>
+  getHttpServerStatus?: () => Promise<HttpServerStatus>
+  onHttpServerTaskCreated?: (callback: (data: any) => void) => void
+  removeHttpServerTaskCreatedListener?: (callback: (data: any) => void) => void
   // Database operations
   getCategories: () => Promise<Category[]>
   addCategory: (name: string) => Promise<Category>


### PR DESCRIPTION

- Introduced HTTP server functionality to allow task creation through GET requests.
- Added settings to enable/disable the HTTP server and configure the port.
- Updated UI to include HTTP server settings in the Setup Modal.
- Integrated HTTP server lifecycle management and task creation events in the main process.
- Enhanced validation for HTTP port configuration.
- Updated tests to cover HTTP server functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Built-in HTTP server: enable/disable, configurable port with validation, auto-start on launch, start/stop during settings save, persisted and included in backup/restore; app refreshes when tasks are created via HTTP.

- **UI**
  - Settings modal adds an “HTTP Server” section with toggle, port input, validation, help text; Setup button shows error state, tooltip/ARIA update, and a red indicator while remaining functional.

- **Tests**
  - Expanded test coverage across UI, settings, auto-refresh, and HTTP server lifecycle, validation, and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->