### PR TITLE
feat(mac): add script to remove quarantine attributes for macOS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@
 
 Context-switch time tracking, my way
 
-## Downloads
-
-Download the latest release for your platform from the [Releases page](https://github.com/rrrekin/TimeCatcher/releases). Available formats include:
-
-- __macOS__: `.dmg` installer
-- __Windows__: `.exe` installer
-- __Linux__: `.AppImage` (portable) and `.snap` packages
-
 ## About This Project
 
 This is me trying vibe coding. I’m a senior Java backend dev poking at tech I don’t know at all to see how far AI agents can take me. I mostly played Product Owner — wrote the asks and sanity‑checked the result.
@@ -36,6 +28,33 @@ No start/stop timers. You just log what you switched to and when; the app sums t
 - Accessible UI with ARIA support
 
 Details on calculation and UI behavior are documented in [CLAUDE.md](./CLAUDE.md) under Report and Duration Calculation.
+
+## Downloads
+
+Download the latest release for your platform from the [Releases page](https://github.com/rrrekin/TimeCatcher/releases).
+
+### Mac
+
+- __Download__: `.dmg` installer from the releases page
+- __Installation__: Open the `.dmg` file and drag TimeCatcher to your Applications folder
+- __First Launch__: The app is unsigned (open source project), so you may need to:
+  1. Right-click the app and select "Open" instead of double-clicking
+  2. Or go to __System Settings__ → __Privacy & Security__ → scroll down to "Security" section and click "Open Anyway" next to TimeCatcher
+  3. Or, if you get a quarantine warning, run: `xattr -d com.apple.quarantine /Applications/TimeCatcher.app`
+
+__Future Enhancement__: Homebrew cask installation is planned but not yet available.
+
+### Windows
+
+- __Download__: `.exe` installer or portable version
+- __Installation__: Run the installer or extract the portable version
+
+### Linux
+
+- __Download__: `.AppImage` (portable) or `.snap` packages
+- __Installation__:
+  - AppImage: Make executable and run directly
+  - Snap: Install via `sudo snap install timecatcher_*.snap --dangerous`
 
 ## Tech Stack
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
       "dist/shared/**/*"
     ],
     "extraResources": [],
+    "afterPack": "./scripts/remove-quarantine.js",
     "mac": {
       "icon": "assets/icon.icns",
       "category": "public.app-category.productivity"

--- a/scripts/remove-quarantine.js
+++ b/scripts/remove-quarantine.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process')
+const path = require('path')
+
+/**
+ * Remove quarantine attributes from macOS app bundle after building
+ * This script is called by electron-builder's afterPack hook
+ */
+async function removeQuarantine(context) {
+  if (context.electronPlatformName !== 'darwin') {
+    console.log('Skipping quarantine removal (not macOS)')
+    return
+  }
+
+  const appPath = context.appOutDir
+  console.log(`Removing quarantine attributes from: ${appPath}`)
+
+  try {
+    // Remove quarantine attributes recursively from the app bundle
+    execSync(`xattr -cr "${appPath}"`, { stdio: 'inherit' })
+    console.log('✅ Successfully removed quarantine attributes')
+  } catch (error) {
+    console.warn('⚠️  Warning: Could not remove quarantine attributes:', error.message)
+    console.warn('This may cause Gatekeeper warnings for users')
+  }
+}
+
+module.exports = removeQuarantine


### PR DESCRIPTION
- Introduced `remove-quarantine.js` executed via `afterPack` hook in `electron-builder` config.
- Improved macOS installation experience by addressing app quarantine warnings.
- Updated README with detailed macOS installation steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Revamped Downloads section with platform-specific install and first-launch instructions for macOS, Windows, and Linux.
  - Added detailed macOS guidance for handling unsigned apps and quarantine workarounds; noted future Homebrew cask.
  - Expanded Windows and Linux steps, including AppImage and Snap guidance.
- Chores
  - Implemented a post-packaging step to remove macOS quarantine attributes from built apps, reducing first-launch friction for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->